### PR TITLE
AST hardening: self-contained node lifetime + schema_name cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,9 @@ if(BUILD_TESTS)
     
     # Advanced Types Support test
     add_parser_test(test_advanced_types tests/test_advanced_types.cpp gtest)
+
+    # AST string lifetime regression test (arena-owned strings outlive tokenizer)
+    add_parser_test(test_ast_lifetime tests/test_ast_lifetime.cpp gtest)
     
     # Parser Code Violations test
     add_parser_test_no_gtest(test_parser_violations tests/test_parser_violations.cpp)

--- a/docs/AST_NOTES.md
+++ b/docs/AST_NOTES.md
@@ -1,0 +1,48 @@
+# AST Notes
+
+Working notes on `ASTNode` field conventions and their intended lifetime /
+ownership. See `include/db25/ast/ast_node.hpp` for the layout (fixed at 128
+bytes, `static_assert`-enforced).
+
+## String lifetime (arena ownership)
+
+Every `std::string_view` stored on an AST node (`primary_text`, `schema_name`,
+`catalog_name`, and any future string field) is copied into the parser's arena
+via `Parser::copy_to_arena()`. AST strings therefore do **not** alias:
+
+- the caller-supplied SQL text buffer passed to `parse()` / `parse_script()`, or
+- the parser's internal tokenizer token buffer.
+
+Because of this, `parse()` and `parse_script()` release the tokenizer before
+returning (matching the error paths). A returned AST is valid for the lifetime
+of the arena — i.e. until the `Parser` is destroyed or `reset()` / a subsequent
+`parse()` / `parse_script()` recycles the arena. Regression coverage lives in
+`tests/test_ast_lifetime.cpp`.
+
+## `schema_name` overloads
+
+`ASTNode::schema_name` is used for more than a literal schema qualifier. Current
+uses, and their status:
+
+- **Name / schema qualifiers** (identifiers, table refs, `CREATE`, `ANALYZE`,
+  `REINDEX`, `PRAGMA`, ...): legitimate use — an actual namespace qualifier.
+- **Table / derived-table aliases** (`NodeFlags::HasAlias`): the alias is stored
+  in `schema_name`. **This is intentional and left as-is** — downstream
+  consumers depend on this convention.
+- **Window frame bound direction** (`FrameBound` nodes): *previously* stored the
+  `"PRECEDING"` / `"FOLLOWING"` keyword in `schema_name`. This was clearly not a
+  name qualifier and has been **moved out**:
+  - direction is now recorded in `semantic_flags` via `FrameBoundFlags`
+    (`FrameBoundPreceding` / `FrameBoundFollowing`; neither set => `CURRENT ROW`
+    or bare `UNBOUNDED`), and
+  - the full human-readable bound text (e.g. `"UNBOUNDED PRECEDING"`,
+    `"5 FOLLOWING"`, `"CURRENT ROW"`) lives in `primary_text`.
+
+## Deferred follow-up: aliases get their own field
+
+Reclaiming `schema_name` fully — i.e. giving table/derived-table **aliases**
+their own dedicated field instead of overloading `schema_name` + `HasAlias` — is
+a deliberate follow-up. It is **not** done here because it changes an AST
+convention that external consumers rely on, and must be coordinated with them
+(and fit within the fixed 128-byte layout). Do not attempt it as part of
+unrelated hardening work.

--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -322,6 +322,22 @@ enum class DataType : uint8_t {
 };
 
 /**
+ * Frame-bound direction flags (window FrameClause bounds).
+ *
+ * Stored in ASTNode::semantic_flags on FrameBound nodes to record the bound's
+ * direction in a machine-readable way. The full human-readable bound text
+ * (e.g. "UNBOUNDED PRECEDING", "5 FOLLOWING", "CURRENT ROW") lives in
+ * primary_text. These flags replace the previous overload that stored the
+ * "PRECEDING"/"FOLLOWING" keyword in schema_name, which is reserved for name
+ * qualifiers / aliases (see docs/AST_NOTES.md).
+ */
+enum FrameBoundFlags : uint16_t {
+    FrameBoundPreceding = 0x0001,  // bound is a PRECEDING bound
+    FrameBoundFollowing = 0x0002   // bound is a FOLLOWING bound
+    // (neither set => CURRENT ROW / bare UNBOUNDED)
+};
+
+/**
  * Convert enum to string for debugging
  * Using C++23 constexpr improvements
  */

--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -113,6 +113,12 @@ public:
      * Parse SQL text and return AST
      * @param sql SQL text to parse
      * @return Root AST node or parse error
+     *
+     * All string data on the returned AST is copied into the parser's arena,
+     * so the AST does not alias either the input @p sql buffer or the internal
+     * tokenizer. The tokenizer is released before this returns; the AST stays
+     * valid until the Parser is destroyed or reset()/parse()/parse_script() is
+     * called again (which recycles the arena).
      */
     [[nodiscard]] ParseResult parse(std::string_view sql);
     

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -140,11 +140,16 @@ ParseResult Parser::parse(std::string_view sql) {
         });
     }
     
-    // Don't delete tokenizer on success - the AST nodes have string_views
-    // pointing to the tokenizer's memory. The tokenizer will be deleted
-    // when the parser is destroyed or reset() is called.
-    // delete tokenizer_;  // KEEP ALIVE for AST string_views
-    // tokenizer_ = nullptr;
+    // All AST node strings are copied into the parser's arena via
+    // copy_to_arena(), so they no longer alias the tokenizer's token buffer.
+    // The tokenizer can therefore be released here (matching the error paths)
+    // without dangling any string_view on the returned AST. The AST's string
+    // lifetime is now tied solely to the arena (i.e. the Parser instance),
+    // independent of the tokenizer.
+    delete tokenizer_;
+    tokenizer_ = nullptr;
+    current_token_ = nullptr;
+    peek_token_ = nullptr;
     return root;
 }
 
@@ -205,7 +210,13 @@ Parser::parse_script(std::string_view sql) {
         }
     }
     
-    // Keep tokenizer alive - AST nodes have string_views pointing to it
+    // AST node strings are arena-owned (copied via copy_to_arena), so they do
+    // not alias the tokenizer buffer. Release the tokenizer here; the returned
+    // AST remains valid for the lifetime of the arena / Parser instance.
+    delete tokenizer_;
+    tokenizer_ = nullptr;
+    current_token_ = nullptr;
+    peek_token_ = nullptr;
     return statements;
 }
 

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1712,10 +1712,11 @@ ast::ASTNode* Parser::parse_window_spec() {
                 current_token_->keyword_id == db25::Keyword::UNBOUNDED) {
                 frame_start->primary_text = copy_to_arena("UNBOUNDED");
                 advance(); // consume UNBOUNDED
-                
+
                 if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
                     current_token_->keyword_id == db25::Keyword::PRECEDING) {
-                    frame_start->schema_name = copy_to_arena("PRECEDING");
+                    frame_start->primary_text = copy_to_arena("UNBOUNDED PRECEDING");
+                    frame_start->semantic_flags |= ast::FrameBoundPreceding;
                     advance(); // consume PRECEDING
                 }
             } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
@@ -1759,10 +1760,14 @@ ast::ASTNode* Parser::parse_window_spec() {
                 // Parse PRECEDING/FOLLOWING
                 if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
                     if (current_token_->keyword_id == db25::Keyword::PRECEDING) {
-                        frame_start->schema_name = copy_to_arena("PRECEDING");
+                        frame_start->primary_text =
+                            copy_to_arena(std::string(frame_start->primary_text) + " PRECEDING");
+                        frame_start->semantic_flags |= ast::FrameBoundPreceding;
                         advance();
                     } else if (current_token_->keyword_id == db25::Keyword::FOLLOWING) {
-                        frame_start->schema_name = copy_to_arena("FOLLOWING");
+                        frame_start->primary_text =
+                            copy_to_arena(std::string(frame_start->primary_text) + " FOLLOWING");
+                        frame_start->semantic_flags |= ast::FrameBoundFollowing;
                         advance();
                     }
                 }
@@ -1786,10 +1791,11 @@ ast::ASTNode* Parser::parse_window_spec() {
                     current_token_->keyword_id == db25::Keyword::UNBOUNDED) {
                     frame_end->primary_text = copy_to_arena("UNBOUNDED");
                     advance(); // consume UNBOUNDED
-                    
+
                     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
                         current_token_->keyword_id == db25::Keyword::FOLLOWING) {
-                        frame_end->schema_name = copy_to_arena("FOLLOWING");
+                        frame_end->primary_text = copy_to_arena("UNBOUNDED FOLLOWING");
+                        frame_end->semantic_flags |= ast::FrameBoundFollowing;
                         advance(); // consume FOLLOWING
                     }
                 } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
@@ -1833,10 +1839,14 @@ ast::ASTNode* Parser::parse_window_spec() {
                     // Parse PRECEDING/FOLLOWING
                     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
                         if (current_token_->keyword_id == db25::Keyword::PRECEDING) {
-                            frame_end->schema_name = copy_to_arena("PRECEDING");
+                            frame_end->primary_text =
+                                copy_to_arena(std::string(frame_end->primary_text) + " PRECEDING");
+                            frame_end->semantic_flags |= ast::FrameBoundPreceding;
                             advance();
                         } else if (current_token_->keyword_id == db25::Keyword::FOLLOWING) {
-                            frame_end->schema_name = copy_to_arena("FOLLOWING");
+                            frame_end->primary_text =
+                                copy_to_arena(std::string(frame_end->primary_text) + " FOLLOWING");
+                            frame_end->semantic_flags |= ast::FrameBoundFollowing;
                             advance();
                         }
                     }

--- a/tests/test_ast_comprehensive.cpp
+++ b/tests/test_ast_comprehensive.cpp
@@ -88,9 +88,14 @@ void print_node(const ASTNode* node, int depth = 0) {
         }
     }
     
-    // Frame boundaries
-    if (node->node_type == NodeType::FrameBound && !node->schema_name.empty()) {
-        std::cout << " " << node->schema_name;
+    // Frame boundaries: direction now lives in semantic_flags (FrameBoundFlags),
+    // with the full bound text in primary_text.
+    if (node->node_type == NodeType::FrameBound) {
+        if (node->semantic_flags & ast::FrameBoundPreceding) {
+            std::cout << " [PRECEDING]";
+        } else if (node->semantic_flags & ast::FrameBoundFollowing) {
+            std::cout << " [FOLLOWING]";
+        }
     }
     
     std::cout << std::endl;

--- a/tests/test_ast_lifetime.cpp
+++ b/tests/test_ast_lifetime.cpp
@@ -1,0 +1,185 @@
+/*
+ * DB25 Parser - AST String Lifetime Regression Tests
+ *
+ * These tests pin down the invariant introduced by the "AST lifetime
+ * hardening" work: every std::string_view stored on an AST node
+ * (primary_text, schema_name, catalog_name, ...) is copied into the
+ * parser's arena and therefore does NOT alias either
+ *   (a) the caller-supplied SQL text buffer, or
+ *   (b) the parser's internal tokenizer token buffer.
+ *
+ * Because parse()/parse_script() now release the tokenizer before they
+ * return, a returned AST that still exposes correct string content proves
+ * the AST outlives the tokenizer.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "db25/ast/ast_node.hpp"
+#include "db25/parser/parser.hpp"
+
+using namespace db25;
+using namespace db25::parser;
+using namespace db25::ast;
+
+namespace {
+
+// Depth-first collection of every node in the tree.
+void collect_nodes(const ASTNode* node, std::vector<const ASTNode*>& out) {
+    if (!node) {
+        return;
+    }
+    out.push_back(node);
+    for (const ASTNode* c = node->first_child; c != nullptr; c = c->next_sibling) {
+        collect_nodes(c, out);
+    }
+}
+
+std::vector<const ASTNode*> all_nodes(const ASTNode* root) {
+    std::vector<const ASTNode*> out;
+    collect_nodes(root, out);
+    return out;
+}
+
+// Find the first node whose primary_text matches `text`.
+const ASTNode* find_by_text(const ASTNode* root, std::string_view text) {
+    for (const ASTNode* n : all_nodes(root)) {
+        if (n->primary_text == text) {
+            return n;
+        }
+    }
+    return nullptr;
+}
+
+// True if `view` points somewhere inside the byte range of `buffer`.
+bool points_into(std::string_view view, const std::string& buffer) {
+    const char* lo = buffer.data();
+    const char* hi = buffer.data() + buffer.size();
+    const char* p = view.data();
+    return p >= lo && p < hi;
+}
+
+}  // namespace
+
+class AstLifetimeTest : public ::testing::Test {
+protected:
+    Parser parser;
+};
+
+// The AST string data must not alias the caller's SQL text buffer: it is an
+// independent arena copy.
+TEST_F(AstLifetimeTest, StringsAreNotAliasedToInputBuffer) {
+    std::string sql = "SELECT alpha_col, beta_col FROM gamma_table WHERE alpha_col = 42";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value()) << "failed to parse test statement";
+    const ASTNode* root = result.value();
+    ASSERT_NE(root, nullptr);
+
+    for (const ASTNode* n : all_nodes(root)) {
+        EXPECT_FALSE(points_into(n->primary_text, sql))
+            << "primary_text '" << n->primary_text
+            << "' aliases the input buffer instead of the arena";
+        EXPECT_FALSE(points_into(n->schema_name, sql))
+            << "schema_name '" << n->schema_name
+            << "' aliases the input buffer instead of the arena";
+        EXPECT_FALSE(points_into(n->catalog_name, sql))
+            << "catalog_name aliases the input buffer instead of the arena";
+    }
+}
+
+// After parse() returns, the internal tokenizer has been destroyed. If any AST
+// string still pointed into the tokenizer's buffer this would be a
+// use-after-free. We reclaim the freed region with heap churn and then verify
+// the AST still reports the correct text.
+TEST_F(AstLifetimeTest, StringsSurviveTokenizerDestruction) {
+    std::string sql =
+        "SELECT customer_id, UPPER(customer_name) FROM customers "
+        "WHERE customer_name = 'widget'";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value());
+    const ASTNode* root = result.value();
+    ASSERT_NE(root, nullptr);
+
+    // Capture views into the (now tokenizer-independent) AST.
+    const ASTNode* tbl = find_by_text(root, "customers");
+    const ASTNode* col = find_by_text(root, "customer_id");
+    const ASTNode* fn = find_by_text(root, "UPPER");
+    ASSERT_NE(tbl, nullptr);
+    ASSERT_NE(col, nullptr);
+    ASSERT_NE(fn, nullptr);
+    std::string_view tbl_view = tbl->primary_text;
+    std::string_view col_view = col->primary_text;
+    std::string_view fn_view = fn->primary_text;
+
+    // Best-effort: scribble a lot of fresh heap allocations to reclaim/overwrite
+    // whatever memory the just-destroyed tokenizer occupied.
+    std::vector<std::string> churn;
+    churn.reserve(4096);
+    for (int i = 0; i < 4096; ++i) {
+        churn.emplace_back(64, static_cast<char>('A' + (i % 26)));
+    }
+
+    // The captured views must still be intact.
+    EXPECT_EQ(tbl_view, "customers");
+    EXPECT_EQ(col_view, "customer_id");
+    EXPECT_EQ(fn_view, "UPPER");
+}
+
+// Mutating (or freeing) the caller's SQL buffer after parsing must not affect
+// the AST, because the AST owns its own arena copy of every string.
+TEST_F(AstLifetimeTest, StringsSurviveInputBufferMutation) {
+    std::string sql = "SELECT payload_col FROM payload_table";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value());
+    const ASTNode* root = result.value();
+    ASSERT_NE(root, nullptr);
+
+    const ASTNode* col = find_by_text(root, "payload_col");
+    const ASTNode* tbl = find_by_text(root, "payload_table");
+    ASSERT_NE(col, nullptr);
+    ASSERT_NE(tbl, nullptr);
+    std::string_view col_view = col->primary_text;
+    std::string_view tbl_view = tbl->primary_text;
+
+    // Obliterate the original SQL buffer contents.
+    std::fill(sql.begin(), sql.end(), 'Z');
+    sql.clear();
+    sql.shrink_to_fit();
+
+    EXPECT_EQ(col_view, "payload_col");
+    EXPECT_EQ(tbl_view, "payload_table");
+}
+
+// Re-parsing (which internally reset()s the arena and recreates the tokenizer)
+// must still yield a fully valid, correct AST for the new statement. This
+// exercises the "second parse() call" path called out in the lifetime work.
+TEST_F(AstLifetimeTest, SecondParseYieldsValidAst) {
+    auto first = parser.parse("SELECT one_col FROM first_table");
+    ASSERT_TRUE(first.has_value());
+    ASSERT_NE(find_by_text(first.value(), "first_table"), nullptr);
+
+    // Different statement; this reset()s the arena and rebuilds the tokenizer.
+    auto second = parser.parse("SELECT two_col FROM second_table WHERE two_col > 7");
+    ASSERT_TRUE(second.has_value());
+    const ASTNode* root = second.value();
+    ASSERT_NE(root, nullptr);
+
+    const ASTNode* tbl = find_by_text(root, "second_table");
+    const ASTNode* col = find_by_text(root, "two_col");
+    ASSERT_NE(tbl, nullptr);
+    ASSERT_NE(col, nullptr);
+    EXPECT_EQ(tbl->primary_text, "second_table");
+    EXPECT_EQ(col->primary_text, "two_col");
+
+    // And its strings are arena-owned, not aliased to the new input either.
+    std::string second_sql = "SELECT two_col FROM second_table WHERE two_col > 7";
+    for (const ASTNode* n : all_nodes(root)) {
+        EXPECT_FALSE(points_into(n->primary_text, second_sql));
+    }
+}

--- a/tests/test_parser_fixes_phase1.cpp
+++ b/tests/test_parser_fixes_phase1.cpp
@@ -334,6 +334,96 @@ TEST_F(ParserFixesPhase1Test, TableAliases) {
     // The exact assertion depends on implementation
 }
 
+// Test 7b: NodeFlags::HasAlias must be reliably set on aliased references and
+// must NOT be set when there is no alias. Downstream (semantic analyzer) relies
+// on this flag being trustworthy.
+TEST_F(ParserFixesPhase1Test, HasAliasFlagIntegrity) {
+    constexpr uint16_t kHasAlias = static_cast<uint16_t>(NodeFlags::HasAlias);
+    auto has_alias = [](const ASTNode* n) {
+        return (n->semantic_flags & static_cast<uint16_t>(NodeFlags::HasAlias)) != 0;
+    };
+
+    // Generic depth-first search for the first node matching a predicate.
+    std::function<const ASTNode*(const ASTNode*, std::function<bool(const ASTNode*)>)>
+        find = [&](const ASTNode* node,
+                   std::function<bool(const ASTNode*)> pred) -> const ASTNode* {
+        if (!node) return nullptr;
+        if (pred(node)) return node;
+        for (auto* c = node->first_child; c; c = c->next_sibling) {
+            if (auto* hit = find(c, pred)) return hit;
+        }
+        return nullptr;
+    };
+
+    // 1. Aliased table reference: FROM users u
+    {
+        auto r = parser.parse("SELECT * FROM users u");
+        ASSERT_TRUE(r.has_value());
+        const ASTNode* tref = find(r.value(), [](const ASTNode* n) {
+            return n->node_type == NodeType::TableRef && n->primary_text == "users";
+        });
+        ASSERT_NE(tref, nullptr);
+        EXPECT_EQ(tref->schema_name, "u");
+        EXPECT_TRUE(has_alias(tref)) << "aliased table ref must set HasAlias";
+    }
+
+    // 2. Non-aliased table reference: FROM users  (flag must NOT be set)
+    {
+        auto r = parser.parse("SELECT * FROM users");
+        ASSERT_TRUE(r.has_value());
+        const ASTNode* tref = find(r.value(), [](const ASTNode* n) {
+            return n->node_type == NodeType::TableRef && n->primary_text == "users";
+        });
+        ASSERT_NE(tref, nullptr);
+        EXPECT_TRUE(tref->schema_name.empty());
+        EXPECT_FALSE(has_alias(tref)) << "non-aliased table ref must NOT set HasAlias";
+    }
+
+    // 3. SELECT-item AS alias: SELECT id AS the_id
+    {
+        auto r = parser.parse("SELECT id AS the_id FROM t");
+        ASSERT_TRUE(r.has_value());
+        const ASTNode* item = find(r.value(), [](const ASTNode* n) {
+            return n->schema_name == "the_id";
+        });
+        ASSERT_NE(item, nullptr);
+        EXPECT_TRUE(has_alias(item)) << "aliased select item must set HasAlias";
+    }
+
+    // 4. Derived-table (subquery) alias: FROM (SELECT ...) sub
+    {
+        auto r = parser.parse("SELECT sub.id FROM (SELECT id FROM t) sub");
+        ASSERT_TRUE(r.has_value());
+        const ASTNode* dt = find(r.value(), [](const ASTNode* n) {
+            return n->node_type == NodeType::Subquery && n->schema_name == "sub";
+        });
+        ASSERT_NE(dt, nullptr);
+        EXPECT_TRUE(has_alias(dt)) << "aliased derived table must set HasAlias";
+    }
+
+    // 5. JOIN with aliases on both sides.
+    {
+        auto r = parser.parse(
+            "SELECT * FROM users u JOIN orders o ON u.id = o.user_id");
+        ASSERT_TRUE(r.has_value());
+        int aliased_tables = 0;
+        std::function<void(const ASTNode*)> walk = [&](const ASTNode* n) {
+            if (!n) return;
+            if (n->node_type == NodeType::TableRef && !n->schema_name.empty()) {
+                EXPECT_TRUE(has_alias(n))
+                    << "joined table '" << n->primary_text << "' aliased '"
+                    << n->schema_name << "' must set HasAlias";
+                aliased_tables++;
+            }
+            for (auto* c = n->first_child; c; c = c->next_sibling) walk(c);
+        };
+        walk(r.value());
+        EXPECT_EQ(aliased_tables, 2) << "both joined tables are aliased";
+    }
+
+    (void)kHasAlias;
+}
+
 // Test 8: Column references should use ColumnRef not Identifier
 TEST_F(ParserFixesPhase1Test, ColumnVsIdentifier) {
     std::string sql = R"(

--- a/tests/test_parser_fixes_phase1.cpp
+++ b/tests/test_parser_fixes_phase1.cpp
@@ -261,17 +261,15 @@ TEST_F(ParserFixesPhase1Test, WindowFrameBoundaries) {
         if (node->node_type == NodeType::WindowSpec) {
             window_specs++;
             
-            // Look for frame bounds
+            // Look for frame bounds. Direction is recorded in semantic_flags
+            // (FrameBoundFlags); the full bound text lives in primary_text.
             for (auto* child = node->first_child; child; child = child->next_sibling) {
-                if (node->node_type == NodeType::FrameBound ||
-                    node->node_type == NodeType::FrameClause) {
-                    // Check if PRECEDING or FOLLOWING is captured
-                    if (node->primary_text.find("PRECEDING") != std::string::npos ||
-                        node->schema_name == "PRECEDING") {
+                if (child->node_type == NodeType::FrameBound ||
+                    child->node_type == NodeType::FrameClause) {
+                    if (child->semantic_flags & ast::FrameBoundPreceding) {
                         preceding_found++;
                     }
-                    if (node->primary_text.find("FOLLOWING") != std::string::npos ||
-                        node->schema_name == "FOLLOWING") {
+                    if (child->semantic_flags & ast::FrameBoundFollowing) {
                         following_found++;
                     }
                 }

--- a/tests/test_parser_fixes_phase2.cpp
+++ b/tests/test_parser_fixes_phase2.cpp
@@ -105,10 +105,11 @@ TEST_F(ParserFixesPhase2Test, WindowFrameBoundaries) {
         if (node->node_type == NodeType::WindowSpec) {
             window_specs++;
         } else if (node->node_type == NodeType::FrameBound) {
-            // Check schema_name for PRECEDING/FOLLOWING
-            if (node->schema_name == "PRECEDING") {
+            // Direction is recorded in semantic_flags (see FrameBoundFlags);
+            // the full bound text lives in primary_text.
+            if (node->semantic_flags & ast::FrameBoundPreceding) {
                 preceding_bounds++;
-            } else if (node->schema_name == "FOLLOWING") {
+            } else if (node->semantic_flags & ast::FrameBoundFollowing) {
                 following_bounds++;
             }
             // Check primary_text for CURRENT ROW
@@ -156,9 +157,13 @@ TEST_F(ParserFixesPhase2Test, UnboundedFrameBoundaries) {
         if (!node) return;
         
         if (node->node_type == NodeType::FrameBound) {
-            if (node->primary_text == "UNBOUNDED" && node->schema_name == "PRECEDING") {
+            // "UNBOUNDED PRECEDING" / "UNBOUNDED FOLLOWING" fold the direction
+            // into primary_text; direction is also flagged in semantic_flags.
+            if (node->primary_text == "UNBOUNDED PRECEDING" &&
+                (node->semantic_flags & ast::FrameBoundPreceding)) {
                 unbounded_preceding++;
-            } else if (node->primary_text == "UNBOUNDED" && node->schema_name == "FOLLOWING") {
+            } else if (node->primary_text == "UNBOUNDED FOLLOWING" &&
+                       (node->semantic_flags & ast::FrameBoundFollowing)) {
                 unbounded_following++;
             }
         }


### PR DESCRIPTION
## Summary

Makes the AST self-contained and independent of the tokenizer's lifetime, and reduces overloading of the `schema_name` field. Prep for downstream consumers (e.g. a semantic-analysis pass). Full suite stays green (29/29 excluding the pre-existing `ArenaEdgeTest`), plus a new lifetime regression test.

## AST string lifetime decoupled from the tokenizer
- Audited every AST string-field assignment (`primary_text`, `schema_name`, `catalog_name`, `display_label`). All were already routed through `copy_to_arena()` or are static literals — the arena-ownership invariant already held, nothing aliased raw token views.
- The remaining gap: `parse()` kept the tokenizer alive solely to keep those `string_view`s valid. Since node text is arena-owned, `parse()` and `parse_script()` now release the tokenizer on success (matching the error paths). The AST's string lifetime is tied to the arena (i.e. the `Parser`), not the tokenizer, so it survives `reset()` / a second `parse()`.
- New regression test `tests/test_ast_lifetime.cpp` (4 cases): strings are not aliased to the input buffer; remain valid after the tokenizer is destroyed (with heap churn); survive input-buffer mutation/free; a second `parse()` yields a valid arena-owned AST.

## Reduced `schema_name` overloading
- `FrameBound` nodes stored `"PRECEDING"`/`"FOLLOWING"` in `schema_name`. Moved the direction into `semantic_flags` (new `FrameBoundFlags`) and the full bound text (`"UNBOUNDED PRECEDING"`, `"5 FOLLOWING"`, `"CURRENT ROW"`) into `primary_text`. `ASTNode` remains exactly 128 bytes (`static_assert` holds). Updated the 3 tests that read those fields.
- Table / derived-table **aliases** remain in `schema_name` + `NodeFlags::HasAlias` (consumers depend on that); `docs/AST_NOTES.md` records the remaining overloads and that a full "aliases get their own field" reclamation is a deliberate, consumer-coordinated follow-up.

## `HasAlias` flag integrity
- Confirmed all three alias sites (table ref, `SELECT ... AS`, implicit select-item alias) set `HasAlias`, and it is never set for DDL schema/owner names. Added a `HasAliasFlagIntegrity` regression test guarding this (set for `FROM users u`, unset for a non-aliased table).

## Verification
- g++-14, portable default (`ENABLE_NATIVE=OFF`, no `-march=native`): builds clean; `ctest -E ArenaEdgeTest` → 100% (29/29), including the new lifetime test. Full run is 29/30 with only `ArenaEdgeTest` failing (the documented frozen-arena over-alignment limitation, unchanged).


