### PR TITLE
Parse qualified star (table.*) into a Star node

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1417,13 +1417,37 @@ ast::ASTNode* Parser::parse_column_ref() {
     
     // Check for qualified name parts
     // Note: The tokenizer might classify "." as Operator, not Delimiter
-    while (current_token_ && 
+    while (current_token_ &&
            (current_token_->type == tokenizer::TokenType::Delimiter ||
             current_token_->type == tokenizer::TokenType::Operator) &&
            current_token_->value == ".") {
         advance(); // consume dot
-        
-        if (current_token_ && 
+
+        // Qualified star: "<qualifier>.*" (e.g. "t.*" or "schema.table.*").
+        // Produce a Star node whose schema_name holds the dotted qualifier so
+        // the downstream semantic analyzer can expand it, and consume the '*'
+        // so the remainder of the statement (FROM, etc.) parses normally.
+        if (current_token_ &&
+            current_token_->type == tokenizer::TokenType::Operator &&
+            current_token_->value == "*") {
+            advance(); // consume '*'
+            auto* star = arena_.allocate<ast::ASTNode>();
+            new (star) ast::ASTNode(ast::NodeType::Star);
+            star->node_id = next_node_id_++;
+
+            std::string qualifier;
+            for (size_t i = 0; i < parts.size(); i++) {
+                if (i > 0) {
+                    qualifier += '.';
+                }
+                qualifier += parts[i];
+            }
+            star->schema_name = copy_to_arena(qualifier);
+            star->primary_text = copy_to_arena("*");
+            return star;
+        }
+
+        if (current_token_ &&
             (current_token_->type == tokenizer::TokenType::Identifier ||
              current_token_->type == tokenizer::TokenType::Keyword)) {
             // Allow keywords as column names in qualified references (e.g., h.level)

--- a/tests/test_parser_select.cpp
+++ b/tests/test_parser_select.cpp
@@ -76,6 +76,88 @@ TEST_F(SelectParserTest, SelectStarHasCorrectStructure) {
     ASSERT_NE(from_clause, nullptr) << "SELECT statement should have FromClause child";
 }
 
+// ============================================================================
+// QUALIFIED STAR TESTS  (table.* -> Star node with schema_name == qualifier)
+// ============================================================================
+
+TEST_F(SelectParserTest, QualifiedStarCarriesQualifier) {
+    auto* ast = parse_select("SELECT t.* FROM t");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::SelectStmt);
+
+    // SELECT list must contain a single Star whose schema_name holds "t".
+    auto* select_list = find_child_by_type(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+    EXPECT_EQ(count_children(select_list), 1);
+
+    auto* star = find_child_by_type(select_list, NodeType::Star);
+    ASSERT_NE(star, nullptr) << "t.* should parse into a Star node";
+    EXPECT_EQ(star->schema_name, "t") << "qualifier 't' must land in schema_name";
+
+    // The FROM clause must still be present and reference table "t".
+    auto* from_clause = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from_clause, nullptr) << "FROM clause must survive qualified star";
+    ASSERT_NE(from_clause->get_first_child(), nullptr);
+    EXPECT_EQ(from_clause->get_first_child()->primary_text, "t");
+}
+
+TEST_F(SelectParserTest, UnqualifiedStarHasEmptyQualifier) {
+    auto* ast = parse_select("SELECT * FROM t");
+    ASSERT_NE(ast, nullptr);
+
+    auto* select_list = find_child_by_type(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+
+    auto* star = find_child_by_type(select_list, NodeType::Star);
+    ASSERT_NE(star, nullptr);
+    EXPECT_TRUE(star->schema_name.empty())
+        << "plain SELECT * must keep an empty schema_name";
+
+    auto* from_clause = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from_clause, nullptr);
+}
+
+TEST_F(SelectParserTest, MixedQualifiedStarAndColumn) {
+    auto* ast = parse_select("SELECT a.*, b.id FROM a JOIN b ON a.id = b.id");
+    ASSERT_NE(ast, nullptr);
+
+    auto* select_list = find_child_by_type(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+    ASSERT_EQ(count_children(select_list), 2);
+
+    // First item: a.* -> Star with schema_name "a".
+    auto* first = select_list->get_first_child();
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->node_type, NodeType::Star);
+    EXPECT_EQ(first->schema_name, "a");
+
+    // Second item: b.id -> ColumnRef, not a Star.
+    auto* second = first->get_next_sibling();
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(second->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(second->primary_text, "b.id");
+
+    // FROM clause still parses (the JOIN did not get swallowed).
+    auto* from_clause = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from_clause, nullptr);
+}
+
+TEST_F(SelectParserTest, MultiPartQualifiedStar) {
+    // schema.table.* -> Star whose schema_name is the full dotted qualifier.
+    auto* ast = parse_select("SELECT s.t.* FROM s.t");
+    ASSERT_NE(ast, nullptr);
+
+    auto* select_list = find_child_by_type(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+
+    auto* star = find_child_by_type(select_list, NodeType::Star);
+    ASSERT_NE(star, nullptr);
+    EXPECT_EQ(star->schema_name, "s.t");
+
+    auto* from_clause = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from_clause, nullptr);
+}
+
 TEST_F(SelectParserTest, SelectListWithColumns) {
     auto* ast = parse_select("SELECT id, name, email FROM users");
     auto children = ast->get_children();


### PR DESCRIPTION
## Summary

`SELECT t.*` did not parse correctly. `t.*` tokenizes as `t` `.` `*`; the qualified-name loop in `parse_column_ref()` consumed the `.` then bailed on the `*`, leaving it behind — the Pratt loop then read `*` as a multiply and swallowed the `FROM` clause. This teaches the parser to recognize qualified star.

## Fix
In `src/parser/parser_select.cpp` `Parser::parse_column_ref()`: right after consuming a qualifier dot, if the next token is operator `*`, consume it and emit a `Star` node instead of continuing to build a `ColumnRef`. All three tokens are consumed, so `FROM`/`JOIN` parse normally.

## AST shape (matches the semantic analyzer's expectation)
- `SELECT t.*` → `NodeType::Star` with `schema_name == "t"`, `primary_text == "*"`.
- `SELECT schema.table.*` → `Star` with `schema_name == "schema.table"` (full dotted qualifier; documented).
- `SELECT *` → unchanged: bare `Star`, empty `schema_name`.

This is exactly the representation the analyzer's qualified-star expansion was written against, so it wires up end-to-end once merged.

## Tests (added to `test_parser_select`)
- `QualifiedStarCarriesQualifier` — `SELECT t.* FROM t`: one `Star` with `schema_name=="t"`, FROM present.
- `UnqualifiedStarHasEmptyQualifier` — `SELECT * FROM t`: `Star` with empty `schema_name`.
- `MixedQualifiedStarAndColumn` — `SELECT a.*, b.id FROM a JOIN b ON a.id = b.id`: first item `Star` (`a`), second `ColumnRef` `b.id`, FROM/JOIN survive.
- `MultiPartQualifiedStar` — `SELECT s.t.* FROM s.t`: `Star` with `schema_name=="s.t"`.

## Verification
g++-14, portable (`ENABLE_NATIVE` off, `-msse4.2` floor, no `-march=native`): `ctest -E ArenaEdgeTest` → 100% (29/29) both before and after, plus the new assertions.


---
_Generated by [Claude Code](https://claude.ai/code)_