### PR TITLE
Fix DML parsing: INSERT column lists, UPDATE/DELETE WHERE, LIMIT, float literals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,9 @@ if(BUILD_TESTS)
     
     # DDL Statements test
     add_parser_test(test_ddl_statements tests/test_ddl_statements.cpp gtest)
+
+    # DML Statements test (INSERT column lists, UPDATE/DELETE WHERE, LIMIT, literals)
+    add_parser_test(test_parser_dml tests/test_parser_dml.cpp gtest)
     
     # SQL Completion test
     add_parser_test_no_gtest(test_sql_completion tests/test_sql_completion.cpp)

--- a/src/parser/parser_dml.cpp
+++ b/src/parser/parser_dml.cpp
@@ -45,8 +45,8 @@ ast::ASTNode* Parser::parse_insert_stmt() {
     ast::ASTNode* last_child = table_ref;
     
     // Optional column list: (col1, col2, ...)
-    if (current_token_ && current_token_->type == tokenizer::TokenType::Operator &&
-        current_token_->value == "(") {
+    // NB: '(' is tokenized as a Delimiter, so match on the value only.
+    if (current_token_ && current_token_->value == "(") {
         
         // Check if it's a column list or VALUES by looking ahead
         // Column list is followed by ) then VALUES/SELECT/DEFAULT

--- a/src/parser/parser_dml.cpp
+++ b/src/parser/parser_dml.cpp
@@ -411,6 +411,7 @@ ast::ASTNode* Parser::parse_update_stmt() {
     
     // Optional WHERE clause
     if (current_token_ && current_token_->keyword_id == db25::Keyword::WHERE) {
+        advance();  // consume WHERE (parse_where_clause parses only the condition)
         auto* where_clause = parse_where_clause();
         if (where_clause) {
             where_clause->parent = update_node;
@@ -544,6 +545,7 @@ ast::ASTNode* Parser::parse_delete_stmt() {
     
     // Optional WHERE clause
     if (current_token_ && current_token_->keyword_id == db25::Keyword::WHERE) {
+        advance();  // consume WHERE (parse_where_clause parses only the condition)
         auto* where_clause = parse_where_clause();
         if (where_clause) {
             where_clause->parent = delete_node;

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -114,13 +114,14 @@ ast::ASTNode* Parser::parse_primary_expression() {
         if (peek_token_ && peek_token_->type == tokenizer::TokenType::Number && op == "-") {
             // For negative numbers, just parse as number with minus
             advance(); // consume -
-            auto* num = arena_.allocate<ast::ASTNode>();
-            new (num) ast::ASTNode(ast::NodeType::IntegerLiteral);
-            num->node_id = next_node_id_++;
-            
             // Combine - with number
             std::string combined = "-";
             combined += std::string(current_token_->value);
+
+            auto* num = arena_.allocate<ast::ASTNode>();
+            new (num) ast::ASTNode(internal::number_literal_type(combined));
+            num->node_id = next_node_id_++;
+
             num->primary_text = copy_to_arena(combined);
             advance();
             return num;
@@ -149,9 +150,9 @@ ast::ASTNode* Parser::parse_primary_expression() {
     // Handle numbers
     if (current_token_->type == tokenizer::TokenType::Number) {
         auto* num = arena_.allocate<ast::ASTNode>();
-        new (num) ast::ASTNode(ast::NodeType::IntegerLiteral);
+        new (num) ast::ASTNode(internal::number_literal_type(current_token_->value));
         num->node_id = next_node_id_++;
-        
+
         num->primary_text = copy_to_arena(current_token_->value);
         advance();
         return num;

--- a/src/parser/parser_internal.hpp
+++ b/src/parser/parser_internal.hpp
@@ -120,4 +120,16 @@ public:
     virtual ~ParserModule() = default;
 };
 
+// Select the correct literal node type for a numeric token.
+// A Number token is a float if its text carries a decimal point or an
+// exponent marker; otherwise it is an integer.
+inline ast::NodeType number_literal_type(std::string_view text) {
+    for (const char c : text) {
+        if (c == '.' || c == 'e' || c == 'E') {
+            return ast::NodeType::FloatLiteral;
+        }
+    }
+    return ast::NodeType::IntegerLiteral;
+}
+
 } // namespace db25::parser::internal

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1237,52 +1237,64 @@ ast::ASTNode* Parser::parse_order_by_clause() {
 }
 
 ast::ASTNode* Parser::parse_limit_clause() {
-    // Parse limit number
-    if (!current_token_ || current_token_->type != tokenizer::TokenType::Number) {
-        // No number after LIMIT
+    // Parse a LIMIT/OFFSET operand. The operand is a numeric literal that may
+    // carry a leading unary minus (e.g. LIMIT -1); the minus is folded into the
+    // literal so the (invalid) value is preserved in the AST for later checks.
+    auto parse_operand = [this]() -> ast::ASTNode* {
+        bool negative = false;
+        if (current_token_ && current_token_->type == tokenizer::TokenType::Operator &&
+            current_token_->value == "-") {
+            negative = true;
+            advance();  // consume -
+        }
+
+        if (!current_token_ || current_token_->type != tokenizer::TokenType::Number) {
+            return nullptr;
+        }
+
+        std::string text;
+        if (negative) {
+            text = "-";
+        }
+        text += std::string(current_token_->value);
+
+        auto* num_node = arena_.allocate<ast::ASTNode>();
+        new (num_node) ast::ASTNode(internal::number_literal_type(text));
+        num_node->node_id = next_node_id_++;
+        num_node->primary_text = copy_to_arena(text);
+        advance();
+        return num_node;
+    };
+
+    // Parse limit operand
+    auto* num_node = parse_operand();
+    if (!num_node) {
+        // No numeric operand after LIMIT
         return nullptr;
     }
-    
-    // Create LIMIT clause node since we have a number
+
+    // Create LIMIT clause node since we have an operand
     auto* limit_node = arena_.allocate<ast::ASTNode>();
     new (limit_node) ast::ASTNode(ast::NodeType::LimitClause);
     limit_node->node_id = next_node_id_++;
-    
-    // Create and add the limit number node
-    auto* num_node = arena_.allocate<ast::ASTNode>();
-    new (num_node) ast::ASTNode(ast::NodeType::IntegerLiteral);
-    num_node->node_id = next_node_id_++;
-    
-    // Store the limit value
-    num_node->primary_text = copy_to_arena(current_token_->value);
-    
+
     num_node->parent = limit_node;
     limit_node->first_child = num_node;
     limit_node->child_count = 1;
-    
-    advance();
-    
+
     // Check for OFFSET
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         current_token_->keyword_id == db25::Keyword::OFFSET) {
         advance();
-        
-        if (current_token_ && current_token_->type == tokenizer::TokenType::Number) {
-            auto* offset_node = arena_.allocate<ast::ASTNode>();
-            new (offset_node) ast::ASTNode(ast::NodeType::IntegerLiteral);
-            offset_node->node_id = next_node_id_++;
-            
-            // Store the offset value
-            offset_node->primary_text = copy_to_arena(current_token_->value);
-            
+
+        auto* offset_node = parse_operand();
+        if (offset_node) {
             offset_node->parent = limit_node;
             num_node->next_sibling = offset_node;
             limit_node->child_count++;
-            
-            advance();
         }
     }
-    
+
     return limit_node;
 }
 

--- a/tests/test_parser_correctness.cpp
+++ b/tests/test_parser_correctness.cpp
@@ -368,10 +368,10 @@ TEST_F(ParserCorrectnessTest, LiteralTypes) {
     EXPECT_EQ(lit2->node_type, NodeType::StringLiteral);
     EXPECT_EQ(lit2->primary_text, "'hello'");
     
-    // Third item should be number (parsed as integer for now)
+    // Third item is a decimal number and should be a float literal
     auto* lit3 = lit2->next_sibling;
     ASSERT_NE(lit3, nullptr);
-    EXPECT_EQ(lit3->node_type, NodeType::IntegerLiteral);
+    EXPECT_EQ(lit3->node_type, NodeType::FloatLiteral);
     EXPECT_EQ(lit3->primary_text, "3.14");
 }
 

--- a/tests/test_parser_dml.cpp
+++ b/tests/test_parser_dml.cpp
@@ -1,0 +1,174 @@
+/*
+ * DB25 Parser - DML Statement Tests
+ * Regression coverage for INSERT column lists, UPDATE/DELETE WHERE clauses,
+ * negative LIMIT operands, and numeric literal typing.
+ */
+
+#include <gtest/gtest.h>
+#include "db25/parser/parser.hpp"
+#include "db25/ast/ast_node.hpp"
+
+using namespace db25;
+using namespace db25::parser;
+using namespace db25::ast;
+
+class DMLParseTest : public ::testing::Test {
+protected:
+    Parser parser;
+
+    void SetUp() override {
+        parser.reset();
+    }
+
+    ASTNode* parse(const std::string& sql) {
+        auto result = parser.parse(sql);
+        if (!result.has_value()) {
+            return nullptr;
+        }
+        return result.value();
+    }
+
+    static ASTNode* find_child(ASTNode* node, NodeType type) {
+        for (auto* c = node ? node->first_child : nullptr; c; c = c->next_sibling) {
+            if (c->node_type == type) {
+                return c;
+            }
+        }
+        return nullptr;
+    }
+};
+
+// ============================================================================
+// INSERT explicit column list
+// ============================================================================
+
+TEST_F(DMLParseTest, InsertWithColumnList) {
+    auto* ast = parse("INSERT INTO t (a, b) VALUES (1, 2)");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::InsertStmt);
+
+    // The parenthesised column list must be parsed into a ColumnList child.
+    auto* column_list = find_child(ast, NodeType::ColumnList);
+    ASSERT_NE(column_list, nullptr);
+    EXPECT_EQ(column_list->child_count, 2u);
+
+    auto* col_a = column_list->first_child;
+    ASSERT_NE(col_a, nullptr);
+    EXPECT_EQ(col_a->primary_text, "a");
+    auto* col_b = col_a->next_sibling;
+    ASSERT_NE(col_b, nullptr);
+    EXPECT_EQ(col_b->primary_text, "b");
+
+    // The VALUES clause must survive alongside the column list.
+    auto* values = find_child(ast, NodeType::ValuesClause);
+    ASSERT_NE(values, nullptr);
+    ASSERT_NE(values->first_child, nullptr);
+    EXPECT_EQ(values->first_child->child_count, 2u);  // (1, 2)
+}
+
+TEST_F(DMLParseTest, InsertWithoutColumnListStillWorks) {
+    auto* ast = parse("INSERT INTO t VALUES (1, 2)");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::InsertStmt);
+
+    // No column list should be present for the unqualified form.
+    EXPECT_EQ(find_child(ast, NodeType::ColumnList), nullptr);
+
+    auto* values = find_child(ast, NodeType::ValuesClause);
+    ASSERT_NE(values, nullptr);
+    ASSERT_NE(values->first_child, nullptr);
+    EXPECT_EQ(values->first_child->child_count, 2u);
+}
+
+// ============================================================================
+// UPDATE / DELETE WHERE clause
+// ============================================================================
+
+TEST_F(DMLParseTest, UpdateWhereClause) {
+    auto* ast = parse("UPDATE t SET a=1 WHERE a=2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::UpdateStmt);
+
+    auto* where = find_child(ast, NodeType::WhereClause);
+    ASSERT_NE(where, nullptr);
+
+    // The condition must be a real predicate, not a stray ColumnRef "WHERE".
+    ASSERT_NE(where->first_child, nullptr);
+    EXPECT_NE(where->first_child->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(where->first_child->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(where->first_child->child_count, 2u);
+}
+
+TEST_F(DMLParseTest, DeleteWhereClause) {
+    auto* ast = parse("DELETE FROM t WHERE a=2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::DeleteStmt);
+
+    auto* where = find_child(ast, NodeType::WhereClause);
+    ASSERT_NE(where, nullptr);
+
+    ASSERT_NE(where->first_child, nullptr);
+    EXPECT_NE(where->first_child->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(where->first_child->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(where->first_child->child_count, 2u);
+}
+
+// ============================================================================
+// LIMIT negative operand
+// ============================================================================
+
+TEST_F(DMLParseTest, LimitNegativeOperandPreserved) {
+    auto* ast = parse("SELECT * FROM t LIMIT -1");
+    ASSERT_NE(ast, nullptr);
+
+    auto* limit = find_child(ast, NodeType::LimitClause);
+    ASSERT_NE(limit, nullptr);
+
+    // The operand must be present and carry the negative value.
+    ASSERT_NE(limit->first_child, nullptr);
+    EXPECT_EQ(limit->first_child->node_type, NodeType::IntegerLiteral);
+    EXPECT_EQ(limit->first_child->primary_text, "-1");
+}
+
+TEST_F(DMLParseTest, LimitPositiveOperandStillWorks) {
+    auto* ast = parse("SELECT * FROM t LIMIT 5");
+    ASSERT_NE(ast, nullptr);
+
+    auto* limit = find_child(ast, NodeType::LimitClause);
+    ASSERT_NE(limit, nullptr);
+    ASSERT_NE(limit->first_child, nullptr);
+    EXPECT_EQ(limit->first_child->primary_text, "5");
+}
+
+// ============================================================================
+// Numeric literal typing
+// ============================================================================
+
+TEST_F(DMLParseTest, FloatLiteralTyping) {
+    auto* ast = parse("SELECT 1.5");
+    ASSERT_NE(ast, nullptr);
+    auto* select_list = find_child(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+    ASSERT_NE(select_list->first_child, nullptr);
+    EXPECT_EQ(select_list->first_child->node_type, NodeType::FloatLiteral);
+    EXPECT_EQ(select_list->first_child->primary_text, "1.5");
+}
+
+TEST_F(DMLParseTest, ExponentLiteralIsFloat) {
+    auto* ast = parse("SELECT 1e3");
+    ASSERT_NE(ast, nullptr);
+    auto* select_list = find_child(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+    ASSERT_NE(select_list->first_child, nullptr);
+    EXPECT_EQ(select_list->first_child->node_type, NodeType::FloatLiteral);
+}
+
+TEST_F(DMLParseTest, IntegerLiteralTyping) {
+    auto* ast = parse("SELECT 1");
+    ASSERT_NE(ast, nullptr);
+    auto* select_list = find_child(ast, NodeType::SelectList);
+    ASSERT_NE(select_list, nullptr);
+    ASSERT_NE(select_list->first_child, nullptr);
+    EXPECT_EQ(select_list->first_child->node_type, NodeType::IntegerLiteral);
+    EXPECT_EQ(select_list->first_child->primary_text, "1");
+}


### PR DESCRIPTION
## Summary

Fixes four parsing bugs surfaced while building DML semantic analysis. `ctest -E ArenaEdgeTest` stays 100% (now 30/30, including a new `test_parser_dml`), portable build.

## Fixes

**1. INSERT explicit column list dropped.** `INSERT INTO t (a, b) VALUES (1, 2)` produced only `InsertStmt → TableRef` — the column list *and* VALUES were lost. The column-list branch was gated on the `(` being an `Operator`, but the tokenizer emits `(` as a `Delimiter`, so it never fired and left the cursor stranded. Now matches by value → `InsertStmt → TableRef, ColumnList(Identifier "a", "b"), ValuesClause`. Unqualified `INSERT INTO t VALUES (...)` is unchanged.

**2. UPDATE/DELETE WHERE mis-parsed.** `UPDATE t SET a=1 WHERE a=2` / `DELETE FROM t WHERE a=2` collapsed the predicate into `WhereClause → ColumnRef "WHERE"`. `parse_where_clause()` assumes the `WHERE` keyword was already consumed (as SELECT does); the DML paths didn't. Consume `WHERE` before delegating → `WhereClause → BinaryExpr "=" → (ColumnRef "a", IntegerLiteral "2")`.

**3. `LIMIT`/`OFFSET` negative operand dropped.** `LIMIT -1` produced no `LimitClause`. The operand parser now folds an optional leading `-` into the literal, for both LIMIT and OFFSET → `LimitClause → IntegerLiteral "-1"` (preserved for a downstream check to reject).

**4. Numeric literal typing.** `1.5` and `1e3` were emitted as `IntegerLiteral`. Added `internal::number_literal_type()` (`FloatLiteral` when the text has `.`/`e`/`E`, else `IntegerLiteral`), used for plain, negated, and LIMIT-operand numbers. Also corrected a stale `test_parser_correctness` assertion that had pinned the old integer-only behaviour for `3.14`.

## Tests
New `tests/test_parser_dml.cpp` (9 cases): INSERT column-list names + surviving VALUES; INSERT-without-list; UPDATE/DELETE `WhereClause` is a `BinaryExpr`; `LIMIT -1` negative operand; `LIMIT 5`; and float/exponent/integer literal typing.

## Impact
These are exactly the shapes the semantic analyzer's DML analysis expects, so its INSERT-column-list / DML-`WHERE` / negative-`LIMIT` cases (currently exercised via synthesized nodes) can move to real end-to-end parsing once this lands.

## Verification
g++-14, portable (`ENABLE_NATIVE` off): `ctest -E ArenaEdgeTest` → 100% (30/30) before/after.


---
_Generated by [Claude Code](https://claude.ai/code)_