### PR TITLE
Tone down README wording and replace decorative icons with plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,20 @@
 # DB25 SQL Parser
 
-<div align="center">
+C++23 · CMake 3.20+ · SIMD · MIT
 
-![C++23](https://img.shields.io/badge/C%2B%2B-23-blue.svg)
-![CMake](https://img.shields.io/badge/CMake-3.20%2B-green.svg)
-![SIMD](https://img.shields.io/badge/SIMD-Optimized-orange.svg)
-![License](https://img.shields.io/badge/License-MIT-yellow.svg)
+A SIMD-optimized SQL parser with AST generation.
 
-**A high-performance, SIMD-optimized SQL parser with comprehensive AST generation**
-
-[Features](#features) • [Quick Start](#quick-start) • [Documentation](#documentation) • [Performance](#performance) • [Contributing](#contributing)
-
-</div>
+[Features](#features) · [Quick Start](#quick-start) · [Documentation](#documentation) · [Performance](#performance) · [Contributing](#contributing)
 
 ## Features
 
-- 🚀 **Blazing Fast**: SIMD-optimized tokenizer with 4.5x speedup
-- 🎯 **Comprehensive**: Supports modern SQL including CTEs, window functions, and more
-- 🛡️ **Secure**: SQLite-inspired depth protection against stack overflow
-- 🔧 **Extensible**: Clean architecture for easy feature additions
-- 📊 **Visual AST**: Professional AST viewer with colored tree output
-- 💾 **Zero-Copy**: Efficient memory usage with string_view throughout
-- 🏗️ **Modern C++23**: Leverages latest language features
+- Fast: SIMD-optimized tokenizer with a 4.5x speedup over the scalar path
+- Broad SQL coverage: CTEs, window functions, and more
+- Depth protection: SQLite-inspired guard against stack overflow
+- Extensible: clean architecture for adding features
+- AST viewer: tree output for inspecting parsed queries
+- Zero-copy: string_view used throughout to reduce allocations
+- Modern C++23
 
 ## Quick Start
 
@@ -81,7 +74,7 @@ int main() {
 
 ### AST Viewer
 
-Visualize your SQL queries as beautiful syntax trees:
+Visualize SQL queries as syntax trees:
 
 ```bash
 # From command line
@@ -124,7 +117,7 @@ Abstract Syntax Tree:
 
 ## Supported SQL Features
 
-### ✅ Data Query Language (DQL)
+### Data Query Language (DQL)
 - SELECT with all standard clauses
 - JOINs (INNER, LEFT, RIGHT, FULL, CROSS, LATERAL)
 - Subqueries (scalar, IN, EXISTS, correlated)
@@ -133,18 +126,18 @@ Abstract Syntax Tree:
 - Set operations (UNION, INTERSECT, EXCEPT)
 - GROUPING SETS, CUBE, ROLLUP
 
-### ✅ Data Manipulation Language (DML)
+### Data Manipulation Language (DML)
 - INSERT (VALUES, SELECT, DEFAULT VALUES)
 - UPDATE with complex expressions
 - DELETE with USING clause
 - RETURNING clause
 
-### ✅ Data Definition Language (DDL)
+### Data Definition Language (DDL)
 - CREATE TABLE/INDEX/VIEW
 - ALTER TABLE
 - DROP with CASCADE
 
-### ✅ Advanced Features
+### Advanced Features
 - CASE expressions
 - CAST operations
 - Complex expressions with precedence
@@ -153,8 +146,6 @@ Abstract Syntax Tree:
 
 ## Performance
 
-<div align="center">
-
 | Component | Performance | Notes |
 |-----------|------------|-------|
 | Tokenizer | 4.5x faster | SIMD-optimized |
@@ -162,14 +153,12 @@ Abstract Syntax Tree:
 | Memory | Zero fragmentation | Arena allocator |
 | Depth | 1001 levels | Stack protection |
 
-</div>
-
 ## Documentation
 
-- 📖 [User Manual](docs/USER_MANUAL.md) - Complete usage guide
-- 🔧 [Developer Guide](docs/DEVELOPER_GUIDE.md) - Architecture and extension guide
-- 📝 [API Reference](docs/API_REFERENCE.md) - Detailed API documentation
-- 🎯 [Examples](tests/showcase_queries.sqls) - Comprehensive SQL examples
+- [User Manual](docs/USER_MANUAL.md) - Usage guide
+- [Developer Guide](docs/DEVELOPER_GUIDE.md) - Architecture and extension guide
+- [API Reference](docs/API_REFERENCE.md) - API documentation
+- [Examples](tests/showcase_queries.sqls) - SQL examples
 
 ## Project Structure
 
@@ -313,16 +302,12 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-- 🐛 [Report Issues](https://github.com/space-rf-org/db25-sql-parser/issues)
-- 💡 [Request Features](https://github.com/space-rf-org/db25-sql-parser/issues)
-- 📧 Contact: chiradip@chiradip.com
+- [Report Issues](https://github.com/space-rf-org/db25-sql-parser/issues)
+- [Request Features](https://github.com/space-rf-org/db25-sql-parser/issues)
+- Contact: chiradip@chiradip.com
 
 ---
 
-<div align="center">
-
-**Built with ❤️ using modern C++23**
+Built with modern C++23.
 
 [Back to Top](#db25-sql-parser)
-
-</div>


### PR DESCRIPTION
## Summary

Adjusts the README's tone to read as project documentation rather than marketing, per request.

- Replaces hyperbolic phrasing with measured equivalents (e.g. "blazing fast" -> "fast"), keeping the substance and any concrete numbers intact.
- Replaces the decorative, colorful emoji/icons with restrained, text-based section markers so the page reads as a technical/research document.

No content or claims were removed beyond softening superlatives; structure and technical detail are preserved.