### PR TITLE
Fix parser correctness bugs: precedence, set-op associativity, arena delete, enum-string rot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,9 +140,10 @@ if(BUILD_TESTS)
     # NOTE: test_parser.cpp, test_parser_sql_suite.cpp, and test_tokenizer_integration.cpp 
     # have been deleted. Only test_tokenizer_verification.cpp remains.
     
-    # TEMPORARILY DISABLED: test_ast has undefined symbols for *_to_string functions
-    # add_executable(test_ast tests/test_ast.cpp)
-    # target_link_libraries(test_ast db25parser gtest_main)
+    # test_ast: exercises the *_to_string helpers and is_statement/is_expression/
+    # is_literal predicates. Re-enabled now that the *_to_string functions have
+    # external linkage (they were constexpr-in-.cpp, hence previously unlinkable).
+    add_parser_test(test_ast tests/test_ast.cpp)
     
     # Tokenizer verification test - verifies correct tokens for parser
     add_parser_test_no_gtest(test_tokenizer_verification tests/test_tokenizer_verification.cpp)
@@ -164,6 +165,7 @@ if(BUILD_TESTS)
     add_parser_test(test_join_comprehensive tests/test_join_comprehensive.cpp)
     
     add_parser_test(test_sql_operators tests/test_sql_operators.cpp)
+    add_parser_test(test_precedence_regression tests/test_precedence_regression.cpp)
     
     add_parser_test(test_group_by tests/test_group_by.cpp)
     

--- a/include/db25/ast/ast_node.hpp
+++ b/include/db25/ast/ast_node.hpp
@@ -163,20 +163,30 @@ struct alignas(128) ASTNode {
     
     // ========== Methods ==========
     
-    // Node type checking
+    // Node type checking. NOTE: these ranges must track the NodeType enum block
+    // boundaries in node_types.hpp. The statement block runs from SelectStmt
+    // through AlterViewStmt (not ExplainStmt, which is mid-block); the literal
+    // block is IntegerLiteral..DateTimeLiteral plus the out-of-block
+    // IntervalLiteral / JsonLiteral; the expression block is BinaryExpr..
+    // WindowExpr plus the value-producing constructor / window nodes.
     [[nodiscard]] constexpr bool is_statement() const noexcept {
-        return node_type >= NodeType::SelectStmt && 
-               node_type <= NodeType::ExplainStmt;
+        return node_type >= NodeType::SelectStmt &&
+               node_type <= NodeType::AlterViewStmt;
     }
-    
+
     [[nodiscard]] constexpr bool is_expression() const noexcept {
-        return node_type >= NodeType::BinaryExpr && 
-               node_type <= NodeType::WindowExpr;
+        return (node_type >= NodeType::BinaryExpr &&
+                node_type <= NodeType::WindowExpr) ||
+               node_type == NodeType::WindowFunction ||
+               node_type == NodeType::ArrayConstructor ||
+               node_type == NodeType::RowConstructor;
     }
-    
+
     [[nodiscard]] constexpr bool is_literal() const noexcept {
-        return node_type >= NodeType::IntegerLiteral && 
-               node_type <= NodeType::DateTimeLiteral;
+        return (node_type >= NodeType::IntegerLiteral &&
+                node_type <= NodeType::DateTimeLiteral) ||
+               node_type == NodeType::IntervalLiteral ||
+               node_type == NodeType::JsonLiteral;
     }
     
     [[nodiscard]] constexpr bool is_identifier() const noexcept {

--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -338,12 +338,16 @@ enum FrameBoundFlags : uint16_t {
 };
 
 /**
- * Convert enum to string for debugging
- * Using C++23 constexpr improvements
+ * Convert enum to string for debugging.
+ *
+ * These are ordinary (non-constexpr) functions defined out-of-line in
+ * ast_node.cpp, so they have external linkage and can be called from any
+ * translation unit that links the library (tools, tests). They were previously
+ * declared constexpr but defined in a .cpp, which emitted no linkable symbol.
  */
-[[nodiscard]] constexpr const char* node_type_to_string(NodeType type) noexcept;
-[[nodiscard]] constexpr const char* binary_op_to_string(BinaryOp op) noexcept;
-[[nodiscard]] constexpr const char* unary_op_to_string(UnaryOp op) noexcept;
-[[nodiscard]] constexpr const char* data_type_to_string(DataType type) noexcept;
+[[nodiscard]] const char* node_type_to_string(NodeType type) noexcept;
+[[nodiscard]] const char* binary_op_to_string(BinaryOp op) noexcept;
+[[nodiscard]] const char* unary_op_to_string(UnaryOp op) noexcept;
+[[nodiscard]] const char* data_type_to_string(DataType type) noexcept;
 
 } // namespace db25::ast

--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -314,6 +314,12 @@ protected:  // Changed from private to allow friend class access
     
     int parenthesis_depth_ = 0;  // Track parenthesis balance
     bool strict_mode_ = true;    // Enable strict validation
+    // True while parsing the right-hand branch of a set operation. It tells
+    // parse_select_stmt to return the bare branch instead of consuming the
+    // following set operators itself, so the caller's loop can fold them
+    // left-associatively (A op B op C -> (A op B) op C). Reset per invocation so
+    // nested subqueries still handle their own set operations.
+    bool in_setop_rhs_ = false;
     
 public:
     // ========== Context Tracking ==========

--- a/src/ast/ast_node.cpp
+++ b/src/ast/ast_node.cpp
@@ -74,9 +74,13 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
     return nullptr;
 }
 
-[[nodiscard]] constexpr const char* node_type_to_string(const NodeType type) noexcept {
+// NOTE: this switch must cover every NodeType enumerator. It is compiled with
+// -Wswitch, so adding a new enumerator without a case here produces a warning
+// rather than silently returning "Unknown". Keep it in sync with node_types.hpp.
+[[nodiscard]] const char* node_type_to_string(const NodeType type) noexcept {
     switch (type) {
         case NodeType::Unknown: return "Unknown";
+        // Statements
         case NodeType::SelectStmt: return "SelectStmt";
         case NodeType::InsertStmt: return "InsertStmt";
         case NodeType::UpdateStmt: return "UpdateStmt";
@@ -89,18 +93,56 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
         case NodeType::TruncateStmt: return "TruncateStmt";
         case NodeType::TransactionStmt: return "TransactionStmt";
         case NodeType::ExplainStmt: return "ExplainStmt";
+        case NodeType::ValuesStmt: return "ValuesStmt";
+        case NodeType::SetStmt: return "SetStmt";
+        case NodeType::VacuumStmt: return "VacuumStmt";
+        case NodeType::AnalyzeStmt: return "AnalyzeStmt";
+        case NodeType::AttachStmt: return "AttachStmt";
+        case NodeType::DetachStmt: return "DetachStmt";
+        case NodeType::ReindexStmt: return "ReindexStmt";
+        case NodeType::PragmaStmt: return "PragmaStmt";
+        case NodeType::BeginStmt: return "BeginStmt";
+        case NodeType::CommitStmt: return "CommitStmt";
+        case NodeType::RollbackStmt: return "RollbackStmt";
+        case NodeType::SavepointStmt: return "SavepointStmt";
+        case NodeType::ReleaseSavepointStmt: return "ReleaseSavepointStmt";
+        case NodeType::CreateTriggerStmt: return "CreateTriggerStmt";
+        case NodeType::CreateSchemaStmt: return "CreateSchemaStmt";
+        case NodeType::CreateFunctionStmt: return "CreateFunctionStmt";
+        case NodeType::CreateProcedureStmt: return "CreateProcedureStmt";
+        case NodeType::AlterSchemaStmt: return "AlterSchemaStmt";
+        case NodeType::AlterIndexStmt: return "AlterIndexStmt";
+        case NodeType::AlterViewStmt: return "AlterViewStmt";
+        // DDL components
+        case NodeType::ColumnDefinition: return "ColumnDefinition";
+        case NodeType::ColumnConstraint: return "ColumnConstraint";
+        case NodeType::TableConstraint: return "TableConstraint";
+        case NodeType::DataTypeNode: return "DataTypeNode";
+        case NodeType::DefaultClause: return "DefaultClause";
+        case NodeType::CheckConstraint: return "CheckConstraint";
+        case NodeType::ForeignKeyConstraint: return "ForeignKeyConstraint";
+        case NodeType::PrimaryKeyConstraint: return "PrimaryKeyConstraint";
+        case NodeType::UniqueConstraint: return "UniqueConstraint";
+        case NodeType::IndexColumn: return "IndexColumn";
+        case NodeType::AlterTableAction: return "AlterTableAction";
+        // Expressions
         case NodeType::BinaryExpr: return "BinaryExpr";
         case NodeType::UnaryExpr: return "UnaryExpr";
         case NodeType::FunctionExpr: return "FunctionExpr";
+        case NodeType::FunctionCall: return "FunctionCall";
         case NodeType::CaseExpr: return "CaseExpr";
         case NodeType::CastExpr: return "CastExpr";
         case NodeType::SubqueryExpr: return "SubqueryExpr";
         case NodeType::ExistsExpr: return "ExistsExpr";
         case NodeType::InExpr: return "InExpr";
         case NodeType::BetweenExpr: return "BetweenExpr";
+        case NodeType::LikeExpr: return "LikeExpr";
+        case NodeType::IsNullExpr: return "IsNullExpr";
         case NodeType::WindowExpr: return "WindowExpr";
+        // Clauses
         case NodeType::SelectList: return "SelectList";
         case NodeType::FromClause: return "FromClause";
+        case NodeType::JoinClause: return "JoinClause";
         case NodeType::WhereClause: return "WhereClause";
         case NodeType::GroupByClause: return "GroupByClause";
         case NodeType::HavingClause: return "HavingClause";
@@ -108,31 +150,69 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
         case NodeType::LimitClause: return "LimitClause";
         case NodeType::WithClause: return "WithClause";
         case NodeType::ReturningClause: return "ReturningClause";
+        case NodeType::OnConflictClause: return "OnConflictClause";
+        case NodeType::UsingClause: return "UsingClause";
+        case NodeType::ValuesClause: return "ValuesClause";
+        case NodeType::GroupingElement: return "GroupingElement";
+        case NodeType::SetClause: return "SetClause";
+        case NodeType::RowExpr: return "RowExpr";
+        // References
         case NodeType::TableRef: return "TableRef";
         case NodeType::ColumnRef: return "ColumnRef";
         case NodeType::AliasRef: return "AliasRef";
         case NodeType::SchemaRef: return "SchemaRef";
+        // Literals
         case NodeType::IntegerLiteral: return "IntegerLiteral";
         case NodeType::FloatLiteral: return "FloatLiteral";
         case NodeType::StringLiteral: return "StringLiteral";
         case NodeType::BooleanLiteral: return "BooleanLiteral";
         case NodeType::NullLiteral: return "NullLiteral";
         case NodeType::DateTimeLiteral: return "DateTimeLiteral";
+        // Joins
         case NodeType::InnerJoin: return "InnerJoin";
         case NodeType::LeftJoin: return "LeftJoin";
         case NodeType::RightJoin: return "RightJoin";
         case NodeType::FullJoin: return "FullJoin";
         case NodeType::CrossJoin: return "CrossJoin";
         case NodeType::LateralJoin: return "LateralJoin";
+        // Other
         case NodeType::Identifier: return "Identifier";
         case NodeType::Star: return "Star";
         case NodeType::Parameter: return "Parameter";
         case NodeType::Comment: return "Comment";
-        default: return "Unknown";
+        // Subquery & CTE
+        case NodeType::Subquery: return "Subquery";
+        case NodeType::CTEClause: return "CTEClause";
+        case NodeType::CTEDefinition: return "CTEDefinition";
+        case NodeType::ColumnList: return "ColumnList";
+        // Window
+        case NodeType::WindowFunction: return "WindowFunction";
+        case NodeType::WindowSpec: return "WindowSpec";
+        case NodeType::PartitionBy: return "PartitionBy";
+        case NodeType::PartitionByClause: return "PartitionByClause";
+        case NodeType::WindowFrame: return "WindowFrame";
+        case NodeType::FrameClause: return "FrameClause";
+        case NodeType::FrameBound: return "FrameBound";
+        // Set operations
+        case NodeType::UnionStmt: return "UnionStmt";
+        case NodeType::IntersectStmt: return "IntersectStmt";
+        case NodeType::ExceptStmt: return "ExceptStmt";
+        // Advanced types
+        case NodeType::IntervalLiteral: return "IntervalLiteral";
+        case NodeType::ArrayConstructor: return "ArrayConstructor";
+        case NodeType::RowConstructor: return "RowConstructor";
+        case NodeType::JsonLiteral: return "JsonLiteral";
+        case NodeType::CollateClause: return "CollateClause";
+        case NodeType::SearchClause: return "SearchClause";
+        case NodeType::CycleClause: return "CycleClause";
+        case NodeType::IsolationLevel: return "IsolationLevel";
+        case NodeType::TransactionMode: return "TransactionMode";
+        case NodeType::MaxNodeType: return "Unknown";  // enum-count sentinel
     }
+    return "Unknown";  // node_type held a value outside the enum
 }
 
-[[nodiscard]] constexpr const char* binary_op_to_string(const BinaryOp op) noexcept {
+[[nodiscard]] const char* binary_op_to_string(const BinaryOp op) noexcept {
     switch (op) {
         case BinaryOp::Add: return "+";
         case BinaryOp::Subtract: return "-";
@@ -163,7 +243,7 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
     }
 }
 
-[[nodiscard]] constexpr const char* unary_op_to_string(const UnaryOp op) noexcept {
+[[nodiscard]] const char* unary_op_to_string(const UnaryOp op) noexcept {
     switch (op) {
         case UnaryOp::Not: return "NOT";
         case UnaryOp::Negate: return "-";
@@ -176,7 +256,7 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
     }
 }
 
-[[nodiscard]] constexpr const char* data_type_to_string(const DataType type) noexcept {
+[[nodiscard]] const char* data_type_to_string(const DataType type) noexcept {
     switch (type) {
         case DataType::Unknown: return "Unknown";
         case DataType::Boolean: return "Boolean";

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -400,24 +400,27 @@ int Parser::get_precedence() const {
         // Don't treat comma or dot as binary operators in expressions
         if (op == "," || op == ".") return 0;
         
-        // Bitwise operators (lowest precedence after logical)
-        if (op == "|") return 2;   // Bitwise OR (lower than concat)
-        if (op == "&") return 2;   // Bitwise AND
-        if (op == "^") return 2;   // Bitwise XOR
-        if (op == "<<" || op == ">>") return 2;  // Bit shifts
-        
-        // String concatenation
-        if (op == "||") return 3;  // String concatenation (lower than comparison)
-        
         // Comparison operators
         if (op == "=") return 4;  // PREC_COMP
         if (op == "<" || op == ">") return 4;  // PREC_COMP
         if (op == "<=" || op == ">=") return 4;  // PREC_COMP
         if (op == "<>" || op == "!=") return 4;  // PREC_COMP
-        
-        // Arithmetic operators
-        if (op == "+" || op == "-") return 5;  // PREC_TERM
-        if (op == "*" || op == "/" || op == "%") return 6;  // PREC_FACTOR
+
+        // String concatenation binds TIGHTER than comparison (a || b = c parses
+        // as (a || b) = c), and looser than the bitwise/arithmetic operators.
+        if (op == "||") return 5;  // PREC_CONCAT
+
+        // Bitwise / shift operators all bind tighter than comparison (so
+        // `flags & 4 = 4` is `(flags & 4) = 4`) and are ranked among themselves
+        // as | < ^ < & < shifts, per common SQL (MySQL) ordering.
+        if (op == "|") return 6;   // Bitwise OR
+        if (op == "^") return 7;   // Bitwise XOR
+        if (op == "&") return 8;   // Bitwise AND
+        if (op == "<<" || op == ">>") return 9;  // Bit shifts
+
+        // Arithmetic operators (tightest binary operators).
+        if (op == "+" || op == "-") return 10;  // PREC_TERM
+        if (op == "*" || op == "/" || op == "%") return 11;  // PREC_FACTOR
         
         // Check for invalid operators (from other languages)
         if (op == "==" || op == "===" || op == "!==") {

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -300,7 +300,13 @@ ast::ASTNode* Parser::parse_with_statement() {
 ast::ASTNode* Parser::parse_select_stmt() {
     DepthGuard guard(this);  // Protect against deep recursion
     if (!guard.is_valid()) return nullptr;
-    
+
+    // Capture whether this invocation is the right-hand branch of an enclosing
+    // set operation, then clear the flag so nested parses (subqueries, the SELECT
+    // list, etc.) handle their own set operations normally.
+    const bool is_setop_rhs = in_setop_rhs_;
+    in_setop_rhs_ = false;
+
     // Prefetch tokens for SELECT statement parsing
     // SELECT statements have predictable structure: SELECT [DISTINCT] columns FROM ...
     if (tokenizer_) {
@@ -458,56 +464,71 @@ ast::ASTNode* Parser::parse_select_stmt() {
         }
     }
     
-    // Check for set operations (UNION, INTERSECT, EXCEPT)
-    if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
+    // Set operations (UNION / INTERSECT / EXCEPT / MINUS) fold LEFT-
+    // associatively: `A op B op C` parses as `(A op B) op C`. If this invocation
+    // is itself the right-hand branch of an enclosing set operation, return the
+    // bare branch and let that caller's loop consume the operator, so the tree is
+    // built left-deep rather than right-deep (which matters for EXCEPT / MINUS).
+    if (is_setop_rhs) {
+        return select_node;
+    }
+    while (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
         std::string_view keyword = current_token_->value;
-        if (keyword == "UNION" || keyword == "union" ||
-            keyword == "INTERSECT" || keyword == "intersect" ||
-            keyword == "EXCEPT" || keyword == "except" ||
-            keyword == "MINUS" || keyword == "minus") {
-            
-            // Create set operation node
-            ast::NodeType set_op_type;
-            if (keyword == "UNION" || keyword == "union") {
-                set_op_type = ast::NodeType::UnionStmt;
-            } else if (keyword == "INTERSECT" || keyword == "intersect") {
-                set_op_type = ast::NodeType::IntersectStmt;
-            } else {
-                set_op_type = ast::NodeType::ExceptStmt;
-            }
-            
-            auto* set_op_node = arena_.allocate<ast::ASTNode>();
-            new (set_op_node) ast::ASTNode(set_op_type);
-            set_op_node->node_id = next_node_id_++;
-            set_op_node->primary_text = copy_to_arena(keyword);
-            
-            advance(); // consume set operation keyword
-            
-            // Check for ALL
-            if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-                (current_token_->keyword_id == db25::Keyword::ALL)) {
-                set_op_node->flags = set_op_node->flags | ast::NodeFlags::All;
-                advance();
-            }
-            
-            // Parse right-hand SELECT
-            ast::ASTNode* right_select = nullptr;
-            if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-                (current_token_->keyword_id == db25::Keyword::SELECT)) {
-                right_select = parse_select_stmt();
-            }
-            
-            if (right_select) {
-                // Set up the tree: set_op_node has left (current select) and right as children
-                select_node->parent = set_op_node;
-                right_select->parent = set_op_node;
-                set_op_node->first_child = select_node;
-                select_node->next_sibling = right_select;
-                set_op_node->child_count = 2;
-                
-                return set_op_node;
-            }
+        if (!(keyword == "UNION" || keyword == "union" ||
+              keyword == "INTERSECT" || keyword == "intersect" ||
+              keyword == "EXCEPT" || keyword == "except" ||
+              keyword == "MINUS" || keyword == "minus")) {
+            break;  // not a set operator: done folding
         }
+
+        // Create the set operation node.
+        ast::NodeType set_op_type;
+        if (keyword == "UNION" || keyword == "union") {
+            set_op_type = ast::NodeType::UnionStmt;
+        } else if (keyword == "INTERSECT" || keyword == "intersect") {
+            set_op_type = ast::NodeType::IntersectStmt;
+        } else {
+            set_op_type = ast::NodeType::ExceptStmt;
+        }
+
+        auto* set_op_node = arena_.allocate<ast::ASTNode>();
+        new (set_op_node) ast::ASTNode(set_op_type);
+        set_op_node->node_id = next_node_id_++;
+        set_op_node->primary_text = copy_to_arena(keyword);
+
+        advance(); // consume set operation keyword
+
+        // Check for ALL
+        if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+            (current_token_->keyword_id == db25::Keyword::ALL)) {
+            set_op_node->flags = set_op_node->flags | ast::NodeFlags::All;
+            advance();
+        }
+
+        // Parse the right-hand branch as a SINGLE SELECT (no set-op tail): the
+        // in_setop_rhs_ guard makes the nested parse_select_stmt return the bare
+        // branch, so THIS loop is what folds successive operators left.
+        ast::ASTNode* right_select = nullptr;
+        if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+            (current_token_->keyword_id == db25::Keyword::SELECT)) {
+            in_setop_rhs_ = true;
+            right_select = parse_select_stmt();
+            in_setop_rhs_ = false;
+        }
+
+        if (!right_select) {
+            // Malformed right-hand side: keep the tree folded so far.
+            break;
+        }
+
+        // Fold left: the accumulated tree becomes the left child of this node,
+        // which in turn becomes the accumulated tree for the next iteration.
+        select_node->parent = set_op_node;
+        right_select->parent = set_op_node;
+        set_op_node->first_child = select_node;
+        select_node->next_sibling = right_select;
+        set_op_node->child_count = 2;
+        select_node = set_op_node;
     }
     
     // Consume any trailing semicolon
@@ -1054,9 +1075,11 @@ ast::ASTNode* Parser::parse_group_by_clause() {
         first_item = parse_expression(0);
     }
     
-    // If we couldn't parse any item, return nullptr
+    // If we couldn't parse any item, return nullptr. group_node is arena-owned
+    // (placement-new'd above), so it must NOT be deleted — the arena reclaims it
+    // in bulk on reset. Calling global delete on arena memory is undefined
+    // behavior; just abandon the node.
     if (!first_item) {
-        delete group_node;
         pop_context();
         return nullptr;
     }

--- a/tests/test_ast.cpp
+++ b/tests/test_ast.cpp
@@ -5,8 +5,10 @@
 using namespace db25::ast;
 
 TEST(ASTNodeTest, SizeAndAlignment) {
-    EXPECT_EQ(sizeof(ASTNode), 64);
-    EXPECT_EQ(alignof(ASTNode), 64);
+    // The node is a 128-byte, 128-byte-aligned (two cache lines) structure; this
+    // is also static_assert-enforced in ast_node.hpp.
+    EXPECT_EQ(sizeof(ASTNode), 128);
+    EXPECT_EQ(alignof(ASTNode), 128);
 }
 
 TEST(ASTNodeTest, DefaultConstruction) {

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -1,0 +1,156 @@
+/*
+ * Regression tests for parser correctness fixes:
+ *   - operator precedence tree shape (|| and bitwise now bind above comparison;
+ *     arithmetic tiers; left-associativity)
+ *   - set-operation LEFT associativity (A EXCEPT B EXCEPT C -> (A EXCEPT B) EXCEPT C)
+ *   - GROUP BY with a missing item does not crash (was: delete on arena memory)
+ *
+ * These pin the exact AST shape so a future precedence/associativity regression
+ * fails loudly rather than silently producing a different tree. The GROUP BY
+ * case also runs under the ASan/UBSan CI job, which is what catches the old
+ * undefined-behavior delete.
+ */
+
+#include <gtest/gtest.h>
+#include "db25/parser/parser.hpp"
+#include "db25/ast/ast_node.hpp"
+#include "db25/ast/node_types.hpp"
+#include <string>
+
+using namespace db25;
+using namespace db25::parser;
+using namespace db25::ast;
+
+class PrecedenceRegressionTest : public ::testing::Test {
+protected:
+    std::unique_ptr<Parser> parser;
+    void SetUp() override { parser = std::make_unique<Parser>(); }
+
+    ASTNode* parse(const std::string& sql) {
+        auto result = parser->parse(sql);
+        return result.has_value() ? result.value() : nullptr;
+    }
+    static ASTNode* find(ASTNode* n, NodeType t) {
+        if (!n) return nullptr;
+        if (n->node_type == t) return n;
+        for (auto* c = n->first_child; c; c = c->next_sibling) {
+            if (auto* h = find(c, t)) return h;
+        }
+        return nullptr;
+    }
+    // First projected expression: SelectList -> first child.
+    ASTNode* first_projection(ASTNode* root) {
+        auto* list = find(root, NodeType::SelectList);
+        return list ? list->first_child : nullptr;
+    }
+    // The WHERE predicate: WhereClause -> first child.
+    ASTNode* where_predicate(ASTNode* root) {
+        auto* w = find(root, NodeType::WhereClause);
+        return w ? w->first_child : nullptr;
+    }
+};
+
+// || binds tighter than comparison: `a || b = c` -> `(a || b) = c`.
+TEST_F(PrecedenceRegressionTest, ConcatAboveComparison) {
+    auto* ast = parse("SELECT a || b = c FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* root = first_projection(ast);
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(root->primary_text, "=");           // comparison is the root
+    auto* left = root->first_child;
+    ASSERT_NE(left, nullptr);
+    EXPECT_EQ(left->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(left->primary_text, "||");          // concat grouped underneath
+}
+
+// Bitwise AND binds tighter than comparison: `flags & 4 = 4` -> `(flags & 4) = 4`.
+TEST_F(PrecedenceRegressionTest, BitwiseAboveComparison) {
+    auto* ast = parse("SELECT * FROM t WHERE flags & 4 = 4");
+    ASSERT_NE(ast, nullptr);
+    auto* root = where_predicate(ast);
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(root->primary_text, "=");
+    auto* left = root->first_child;
+    ASSERT_NE(left, nullptr);
+    EXPECT_EQ(left->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(left->primary_text, "&");
+}
+
+// Multiplication binds tighter than addition: `1 + 2 * 3` -> `1 + (2 * 3)`.
+TEST_F(PrecedenceRegressionTest, MultiplicativeAboveAdditive) {
+    auto* ast = parse("SELECT 1 + 2 * 3 FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* root = first_projection(ast);
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->primary_text, "+");
+    auto* right = root->first_child->next_sibling;
+    ASSERT_NE(right, nullptr);
+    EXPECT_EQ(right->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(right->primary_text, "*");
+}
+
+// Subtraction is left-associative: `a - b - c` -> `(a - b) - c`.
+TEST_F(PrecedenceRegressionTest, SubtractionLeftAssociative) {
+    auto* ast = parse("SELECT a - b - c FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* root = first_projection(ast);
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->primary_text, "-");
+    auto* left = root->first_child;
+    ASSERT_NE(left, nullptr);
+    EXPECT_EQ(left->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(left->primary_text, "-");           // the inner (a - b)
+}
+
+// AND binds tighter than OR: `a AND b OR c` -> `(a AND b) OR c`.
+TEST_F(PrecedenceRegressionTest, AndAboveOr) {
+    auto* ast = parse("SELECT * FROM t WHERE a AND b OR c");
+    ASSERT_NE(ast, nullptr);
+    auto* root = where_predicate(ast);
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(root->primary_text, "OR");
+    auto* left = root->first_child;
+    ASSERT_NE(left, nullptr);
+    EXPECT_EQ(left->primary_text, "AND");
+}
+
+// Set operations fold LEFT: `A EXCEPT B EXCEPT C` -> `(A EXCEPT B) EXCEPT C`.
+// The outer node's left child must itself be an EXCEPT (left-deep), not the
+// right child (which would be right-associative and wrong for EXCEPT).
+TEST_F(PrecedenceRegressionTest, SetOpLeftAssociative) {
+    auto* ast = parse(
+        "SELECT a FROM t1 EXCEPT SELECT b FROM t2 EXCEPT SELECT c FROM t3");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::ExceptStmt);
+    auto* left = ast->first_child;
+    auto* right = left ? left->next_sibling : nullptr;
+    ASSERT_NE(left, nullptr);
+    ASSERT_NE(right, nullptr);
+    EXPECT_EQ(left->node_type, NodeType::ExceptStmt);   // (A EXCEPT B) on the left
+    EXPECT_EQ(right->node_type, NodeType::SelectStmt);  // C on the right
+}
+
+// A UNION also folds left, and mixed chains keep left-deep shape.
+TEST_F(PrecedenceRegressionTest, UnionChainLeftAssociative) {
+    auto* ast = parse(
+        "SELECT a FROM t1 UNION SELECT b FROM t2 UNION SELECT c FROM t3");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::UnionStmt);
+    ASSERT_NE(ast->first_child, nullptr);
+    EXPECT_EQ(ast->first_child->node_type, NodeType::UnionStmt);
+}
+
+// GROUP BY with a missing item must not crash (regression: the old code called
+// global delete on an arena-allocated node -> UB). The parser is lenient, so it
+// still returns a SelectStmt; the point is that it completes cleanly (and does
+// so under ASan/UBSan in CI).
+TEST_F(PrecedenceRegressionTest, GroupByMissingItemNoCrash) {
+    auto* ast = parse("SELECT x FROM t GROUP BY");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::SelectStmt);
+    // No GroupByClause child should have been attached (the item failed to parse).
+    EXPECT_EQ(find(ast, NodeType::GroupByClause), nullptr);
+}


### PR DESCRIPTION
## Summary

Four correctness fixes surfaced by the deep parser review, each applied and tested one at a time (build + full `ctest` after every change) so no step regressed. Verified under **Release (g++-13 and g++-14)** and **Debug + ASan/UBSan**; the previously-disabled `test_ast` is re-enabled and a new regression suite pins every fixed behavior. **32/32 tests pass.**

## Fixes

**1. Arena `delete` -> UB (crash).** `parse_group_by_clause` called global `delete` on an arena-allocated node when `GROUP BY` had no parsable item (`SELECT x FROM t GROUP BY`). Arena memory must never be `delete`d — the node is now simply abandoned. Validated under ASan by the new no-crash regression test.

**2. Set-operation associativity.** The right branch was parsed with a recursive `parse_select_stmt` that consumed further set operators, so `A EXCEPT B EXCEPT C` built `A EXCEPT (B EXCEPT C)` — a **wrong result set** for the non-associative `EXCEPT`/`MINUS`. A per-invocation `in_setop_rhs_` guard makes each branch parse without its set-op tail, so the loop folds operators **left**: `(A EXCEPT B) EXCEPT C`. Nested subqueries still handle their own set operations (the flag is reset per invocation).

**3. Operator precedence.** String concatenation `||` and the bitwise/shift operators sat **below** comparison, so `a || b = c` parsed as `a || (b = c)` and `flags & 4 = 4` as `flags & (4 = 4)`. They now bind **tighter than comparison** (`||` just above comparison; `|` < `^` < `&` < shifts < arithmetic), matching standard SQL. The core `OR < AND < predicate < comparison < additive < multiplicative` order and left-associativity are unchanged.

**4. Enum-string / predicate rot.** `node_type_to_string` handled ~55 of ~130 node types (everything newer stringified as `"Unknown"`), and `is_statement`/`is_literal` used stale enum ranges (statements past `ExplainStmt`, out-of-block literals misclassified). `node_type_to_string` now covers **every** enumerator with the `default:` removed, so `-Wswitch` flags any future gap at compile time; the `is_*` predicates track the enum block boundaries. The `*_to_string` helpers were `constexpr`-defined in a `.cpp` (no linkable symbol, which is why `test_ast` was disabled and tools carried private copies) — they are now ordinary external functions.

## Tests

- **Re-enabled `tests/test_ast.cpp`** (linkable again; updated its stale 64-byte size assertion to the current, `static_assert`-enforced 128).
- **New `tests/test_precedence_regression.cpp`** — 8 cases pinning: `||`/bitwise above comparison, multiplicative-above-additive, subtraction left-associativity, `AND`-above-`OR`, set-op left-associativity (EXCEPT and UNION chains), and the `GROUP BY` no-crash path.
- `-Wswitch` surfaced (and I handled) the `MaxNodeType` sentinel while completing the switch — the anti-rot mechanism working as intended.

## Not included (out of scope, noted for follow-up)

The lower-severity items from the review are intentionally left out to keep this focused: `BETWEEN` bounds can still absorb a comparison, the dead `ParserModule` scaffolding with its stale `[[noreturn]]`, `parse_script` not resetting the arena, and `get_children()`'s shared thread-local buffer.