### PR TITLE
Make the DepthGuard recursion-safety test real and CI-gated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,9 @@ if(BUILD_TESTS)
     
     # Comprehensive AST dump test - combines all visual dump functionality
     add_parser_test_no_gtest(test_ast_dump tests/test_ast_dump.cpp)
+
+    # DepthGuard security test - recursion depth protection against stack overflow
+    add_parser_test(test_depth_guard tests/security/test_depth_guard.cpp)
     
     # Add custom target for generating visual dumps
     add_custom_target(generate_ast_dumps

--- a/tests/security/test_depth_guard.cpp
+++ b/tests/security/test_depth_guard.cpp
@@ -1,208 +1,129 @@
 /*
- * Test DepthGuard protection against stack overflow
+ * DepthGuard security test.
+ *
+ * Verifies that the parser's recursion DepthGuard protects against stack
+ * overflow from maliciously (or accidentally) deep nesting. These are real,
+ * gating assertions: deeply nested inputs MUST be rejected with a graceful
+ * error Result rather than crashing or overflowing the stack, custom depth
+ * limits MUST be honoured, and the parser MUST remain usable after a depth
+ * failure.
  */
 
-#include <iostream>
 #include <string>
 #include <sstream>
+
+#include <gtest/gtest.h>
+
 #include "db25/parser/parser.hpp"
 
 using namespace db25;
 using namespace db25::parser;
 
-// Colors for output
-const char* GREEN = "\033[32m";
-const char* RED = "\033[31m";
-const char* YELLOW = "\033[33m";
-const char* CYAN = "\033[36m";
-const char* RESET = "\033[0m";
-const char* BOLD = "\033[1m";
+namespace {
 
-// Generate deeply nested SQL
-std::string generate_nested_sql(int depth) {
+// The error message emitted by the guard when the limit is exceeded.
+constexpr const char* kDepthError = "Maximum recursion depth exceeded";
+
+// Generate deeply nested subqueries: SELECT * FROM (SELECT * FROM (... SELECT 1 ...))
+std::string generate_nested_subqueries(int depth) {
     std::stringstream sql;
-    
-    // Generate nested subqueries
-    for (int i = 0; i < depth; i++) {
+    for (int i = 0; i < depth; ++i) {
         sql << "SELECT * FROM (";
     }
-    
     sql << "SELECT 1";
-    
-    for (int i = 0; i < depth; i++) {
+    for (int i = 0; i < depth; ++i) {
         sql << ") AS t" << i;
     }
-    
     return sql.str();
 }
 
-// Generate deeply nested expressions
+// Generate deeply nested parenthesised expressions: SELECT (1 + (1 + ( ... 1 ... )))
 std::string generate_nested_expr(int depth) {
     std::stringstream sql;
     sql << "SELECT ";
-    
-    for (int i = 0; i < depth; i++) {
+    for (int i = 0; i < depth; ++i) {
         sql << "(1 + ";
     }
-    
     sql << "1";
-    
-    for (int i = 0; i < depth; i++) {
+    for (int i = 0; i < depth; ++i) {
         sql << ")";
     }
-    
     sql << " AS result";
     return sql.str();
 }
 
-// Generate deeply recursive CTE
-std::string generate_recursive_cte(int depth) {
-    std::stringstream sql;
-    sql << "WITH RECURSIVE cte AS (";
-    sql << "SELECT 1 AS n ";
-    sql << "UNION ALL ";
-    sql << "SELECT n + 1 FROM cte WHERE n < " << depth;
-    sql << ") SELECT * FROM cte";
-    return sql.str();
+}  // namespace
+
+// A modestly nested query stays well under the default limit and must parse.
+TEST(DepthGuard, ShallowNestedQueryParses) {
+    Parser parser;
+    const std::string sql = generate_nested_subqueries(10);
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value())
+        << "Shallow query should parse, got error: " << result.error().message;
 }
 
-int main() {
-    std::cout << BOLD << "========================================" << RESET << std::endl;
-    std::cout << BOLD << "DB25 Parser - DepthGuard Test" << RESET << std::endl;
-    std::cout << BOLD << "========================================" << RESET << std::endl;
-    std::cout << std::endl;
-    
+// Deeply nested subqueries that exceed the default depth limit must be
+// rejected gracefully (error Result, no crash, no stack overflow).
+TEST(DepthGuard, DeeplyNestedSubqueriesRejected) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+    const std::string sql = generate_nested_subqueries(static_cast<int>(limit) * 3);
+
+    auto result = parser.parse(sql);
+    ASSERT_FALSE(result.has_value())
+        << "Deeply nested subqueries must be rejected by the DepthGuard";
+    EXPECT_EQ(result.error().message, kDepthError);
+}
+
+// Deeply nested parenthesised expressions must likewise be rejected gracefully.
+TEST(DepthGuard, DeeplyNestedExpressionsRejected) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+    const std::string sql = generate_nested_expr(static_cast<int>(limit) * 3);
+
+    auto result = parser.parse(sql);
+    ASSERT_FALSE(result.has_value())
+        << "Deeply nested expressions must be rejected by the DepthGuard";
+    EXPECT_EQ(result.error().message, kDepthError);
+}
+
+// A custom (lower) depth limit must be honoured: inputs within the limit parse,
+// inputs beyond it are rejected.
+TEST(DepthGuard, CustomDepthLimitHonored) {
     Parser parser;
     ParserConfig config = parser.config();
-    std::cout << "Default max depth: " << CYAN << config.max_depth << RESET << std::endl;
-    std::cout << std::endl;
-    
-    // Test 1: Normal query (should pass)
-    std::cout << BOLD << "Test 1: Normal nested query (depth 10)" << RESET << std::endl;
+    config.max_depth = 50;
+    parser.set_config(config);
+
+    // Comfortably within the custom limit.
     {
-        std::string sql = generate_nested_sql(10);
-        std::cout << "Query length: " << sql.length() << " bytes" << std::endl;
-        
-        auto result = parser.parse(sql);
-        if (result.has_value()) {
-            std::cout << GREEN << "✓ Parsed successfully" << RESET << std::endl;
-        } else {
-            std::cout << RED << "✗ Parse failed: " << result.error().message << RESET << std::endl;
-        }
+        auto ok = parser.parse(generate_nested_subqueries(10));
+        ASSERT_TRUE(ok.has_value())
+            << "Query within custom limit should parse, got: " << ok.error().message;
     }
-    std::cout << std::endl;
-    
-    // Test 2: Deep nesting near limit (should pass)
-    std::cout << BOLD << "Test 2: Deep nested query (depth 500)" << RESET << std::endl;
+
+    // Well beyond the custom limit.
     {
-        std::string sql = generate_nested_sql(500);
-        std::cout << "Query length: " << sql.length() << " bytes" << std::endl;
-        
-        auto result = parser.parse(sql);
-        if (result.has_value()) {
-            std::cout << GREEN << "✓ Parsed successfully" << RESET << std::endl;
-        } else {
-            std::cout << RED << "✗ Parse failed: " << result.error().message << RESET << std::endl;
-        }
+        auto bad = parser.parse(generate_nested_subqueries(200));
+        ASSERT_FALSE(bad.has_value())
+            << "Query beyond custom limit must be rejected";
+        EXPECT_EQ(bad.error().message, kDepthError);
     }
-    std::cout << std::endl;
-    
-    // Test 3: Exceed depth limit (should fail with depth error)
-    std::cout << BOLD << "Test 3: Excessive nested query (depth 1500)" << RESET << std::endl;
-    {
-        std::string sql = generate_nested_sql(1500);
-        std::cout << "Query length: " << sql.length() << " bytes" << std::endl;
-        
-        auto result = parser.parse(sql);
-        if (result.has_value()) {
-            std::cout << RED << "✗ SECURITY ISSUE: Should have failed!" << RESET << std::endl;
-        } else {
-            const auto& error = result.error();
-            if (error.message == "Maximum recursion depth exceeded") {
-                std::cout << GREEN << "✓ Correctly blocked: " << error.message << RESET << std::endl;
-            } else {
-                std::cout << YELLOW << "⚠ Failed with different error: " << error.message << RESET << std::endl;
-            }
-        }
-    }
-    std::cout << std::endl;
-    
-    // Test 4: Deep expression nesting
-    std::cout << BOLD << "Test 4: Deep nested expression (depth 1200)" << RESET << std::endl;
-    {
-        std::string sql = generate_nested_expr(1200);
-        std::cout << "Query length: " << sql.length() << " bytes" << std::endl;
-        
-        auto result = parser.parse(sql);
-        if (result.has_value()) {
-            std::cout << RED << "✗ SECURITY ISSUE: Should have failed!" << RESET << std::endl;
-        } else {
-            const auto& error = result.error();
-            if (error.message == "Maximum recursion depth exceeded") {
-                std::cout << GREEN << "✓ Correctly blocked: " << error.message << RESET << std::endl;
-            } else {
-                std::cout << YELLOW << "⚠ Failed with different error: " << error.message << RESET << std::endl;
-            }
-        }
-    }
-    std::cout << std::endl;
-    
-    // Test 5: Custom depth limit
-    std::cout << BOLD << "Test 5: Custom depth limit (max_depth = 50)" << RESET << std::endl;
-    {
-        ParserConfig custom_config = config;
-        custom_config.max_depth = 50;
-        parser.set_config(custom_config);
-        
-        std::string sql = generate_nested_sql(100);
-        std::cout << "Query with depth 100, limit 50" << std::endl;
-        
-        auto result = parser.parse(sql);
-        if (result.has_value()) {
-            std::cout << RED << "✗ SECURITY ISSUE: Should have failed!" << RESET << std::endl;
-        } else {
-            const auto& error = result.error();
-            if (error.message == "Maximum recursion depth exceeded") {
-                std::cout << GREEN << "✓ Correctly blocked at custom limit" << RESET << std::endl;
-            } else {
-                std::cout << YELLOW << "⚠ Failed with different error: " << error.message << RESET << std::endl;
-            }
-        }
-        
-        // Reset to default config
-        parser.set_config(config);
-    }
-    std::cout << std::endl;
-    
-    // Test 6: Parser reuse after depth exceeded
-    std::cout << BOLD << "Test 6: Parser reuse after depth exceeded" << RESET << std::endl;
-    {
-        // First, trigger depth exceeded
-        std::string deep_sql = generate_nested_sql(1500);
-        auto result1 = parser.parse(deep_sql);
-        if (!result1.has_value() && result1.error().message == "Maximum recursion depth exceeded") {
-            std::cout << GREEN << "✓ First query blocked correctly" << RESET << std::endl;
-        }
-        
-        // Now try a normal query
-        std::string normal_sql = "SELECT * FROM users WHERE id = 1";
-        auto result2 = parser.parse(normal_sql);
-        if (result2.has_value()) {
-            std::cout << GREEN << "✓ Parser correctly reset and parsed normal query" << RESET << std::endl;
-        } else {
-            std::cout << RED << "✗ Parser failed to reset: " << result2.error().message << RESET << std::endl;
-        }
-    }
-    std::cout << std::endl;
-    
-    // Summary
-    std::cout << BOLD << "========================================" << RESET << std::endl;
-    std::cout << GREEN << "DepthGuard is working correctly!" << RESET << std::endl;
-    std::cout << "The parser is protected against:" << std::endl;
-    std::cout << "  • Stack overflow attacks" << std::endl;
-    std::cout << "  • Deeply nested malicious queries" << std::endl;
-    std::cout << "  • Infinite recursion bugs" << std::endl;
-    std::cout << BOLD << "========================================" << RESET << std::endl;
-    
-    return 0;
+}
+
+// After a depth failure the parser must reset cleanly and remain reusable.
+TEST(DepthGuard, ParserReusableAfterDepthFailure) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+
+    auto deep = parser.parse(generate_nested_subqueries(static_cast<int>(limit) * 3));
+    ASSERT_FALSE(deep.has_value());
+    ASSERT_EQ(deep.error().message, kDepthError);
+
+    // The parser must recover and parse an ordinary query.
+    auto ok = parser.parse("SELECT * FROM users WHERE id = 1");
+    ASSERT_TRUE(ok.has_value())
+        << "Parser must be reusable after a depth failure, got: "
+        << ok.error().message;
 }


### PR DESCRIPTION
## Summary

The parser's recursion-safety feature (`DepthGuard`) had a test at `tests/security/test_depth_guard.cpp` that (a) was **not registered in any CMakeLists**, so CI never built or ran it, and (b) `return 0` unconditionally after printing "SECURITY ISSUE", so it could never fail even if run. This makes it a real, gating test.

## Changes

- **Rewrote `tests/security/test_depth_guard.cpp`** as a gtest suite with real assertions:
  - `ShallowNestedQueryParses` — a modestly nested query parses.
  - `DeeplyNestedSubqueriesRejected` — subqueries well past `max_depth` return an error Result (`"Maximum recursion depth exceeded"`) with no crash / stack overflow.
  - `DeeplyNestedExpressionsRejected` — same for deeply nested parenthesized expressions.
  - `CustomDepthLimitHonored` — with `max_depth = 50`, a within-limit query parses and an over-limit one is rejected.
  - `ParserReusableAfterDepthFailure` — the parser recovers and parses a normal query after a depth failure.
  - Depths derive from `parser.config().max_depth`; the deep cases run in single-digit ms.
- **Registered it in `CMakeLists.txt`** via `add_parser_test` so `ctest` runs it.

## Verification

- Release suite (`ctest -E ArenaEdgeTest`): **31/31 pass** (was 30 — this adds one).
- Debug **ASan/UBSan** build: **31/31 pass**, `test_depth_guard` clean — proving the deep-nesting path neither overflows the stack nor triggers UB.
- Gating proof: temporarily raising `max_depth` to 100000 makes the deep query parse, which trips the test's `ASSERT_FALSE(has_value())` — confirming the assertions genuinely depend on the guard working (that probe was not committed).

Independent of the `parser-correctness-fixes` branch; based on `main`.