### PR TITLE
Fix DML correctness bugs: schema-qualified names (data-loss), keyword-case gating, INSERT RETURNING/ON CONFLICT, trailing-input detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,10 @@ if(BUILD_TESTS)
 
     # DML Statements test (INSERT column lists, UPDATE/DELETE WHERE, LIMIT, literals)
     add_parser_test(test_parser_dml tests/test_parser_dml.cpp gtest)
+
+    # Parser correctness round 2 (schema-qualified tables, trailing-input
+    # detection, case-insensitive DML keywords, INSERT RETURNING/ON CONFLICT)
+    add_parser_test(test_parser_correctness_round2 tests/test_parser_correctness_round2.cpp gtest)
     
     # SQL Completion test
     add_parser_test_no_gtest(test_sql_completion tests/test_sql_completion.cpp)

--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -125,6 +125,21 @@ public:
      */
     [[nodiscard]] size_t get_memory_used() const noexcept;
     [[nodiscard]] size_t get_node_count() const noexcept;
+
+    // ========== Trailing-input Diagnostics ==========
+    //
+    // The parser is intentionally lenient: parse() still returns success when
+    // tokens remain after a complete statement (silent truncation), so this is
+    // exposed as a queryable diagnostic rather than a hard parse failure. After
+    // a parse()/parse_script() call these report how much input was left
+    // unconsumed past the parsed statement(s) (a single trailing ';' terminator
+    // is NOT counted). Reset at the start of every parse.
+
+    /// Number of significant tokens left unconsumed after the last parse.
+    [[nodiscard]] size_t trailing_token_count() const noexcept { return trailing_token_count_; }
+
+    /// True when the last parse left significant trailing input unconsumed.
+    [[nodiscard]] bool has_trailing_input() const noexcept { return trailing_token_count_ > 0; }
     
     // ========== Configuration ==========
     
@@ -350,6 +365,10 @@ private:
     // so parse()/parse_script() can surface a ParseError on malformed input.
     bool has_error_ = false;         // A parse error was recorded during the current parse
     std::string error_message_;      // Message of the first recorded error
+
+    // Count of significant tokens left after the parsed statement(s). Surfaced
+    // via trailing_token_count()/has_trailing_input(); does not affect success.
+    size_t trailing_token_count_ = 0;
 };
 
 } // namespace db25::parser

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -140,6 +140,31 @@ ParseResult Parser::parse(std::string_view sql) {
         });
     }
     
+    // Trailing-input detection (lenient): the statement parsed successfully,
+    // but the parser may have stopped before consuming all input. Record how
+    // many significant tokens remain so callers can detect silent truncation
+    // via has_trailing_input()/trailing_token_count(). This intentionally does
+    // NOT turn trailing input into a parse failure (that regressed ~8 suites);
+    // success is preserved. A single trailing ';' terminator is not counted.
+    if (tokenizer_) {
+        const auto& tokens = tokenizer_->get_tokens();
+        size_t idx = tokenizer_->position();
+        // Skip exactly one trailing statement terminator ';'.
+        if (idx < tokens.size() &&
+            tokens[idx].type == tokenizer::TokenType::Delimiter &&
+            tokens[idx].value == ";") {
+            ++idx;
+        }
+        size_t remaining = 0;
+        for (; idx < tokens.size(); ++idx) {
+            if (tokens[idx].type == tokenizer::TokenType::EndOfFile) {
+                continue;
+            }
+            ++remaining;
+        }
+        trailing_token_count_ = remaining;
+    }
+
     // All AST node strings are copied into the parser's arena via
     // copy_to_arena(), so they no longer alias the tokenizer's token buffer.
     // The tokenizer can therefore be released here (matching the error paths)
@@ -229,6 +254,7 @@ void Parser::reset() {
     depth_exceeded_ = false;  // Reset depth exceeded flag
     has_error_ = false;       // Reset recoverable error state
     error_message_.clear();
+    trailing_token_count_ = 0; // Reset trailing-input diagnostic
     delete tokenizer_;  // Safe even if nullptr
     tokenizer_ = nullptr;
     current_token_ = nullptr;

--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -981,7 +981,7 @@ ast::ASTNode* Parser::parse_alter_table_full() {
                 }
             }
         }
-    } else if (current_token_ && current_token_->value == "RENAME") {
+    } else if (current_token_ && current_token_->keyword_id == db25::Keyword::RENAME) {
         advance();
         action->primary_text = copy_to_arena("RENAME");
         
@@ -1196,7 +1196,7 @@ ast::ASTNode* Parser::parse_create_trigger() {
     } else if (current_token_ && current_token_->keyword_id == db25::Keyword::AFTER) {
         trigger_node->semantic_flags |= 0x20;  // AFTER flag
         advance();
-    } else if (current_token_ && current_token_->value == "INSTEAD") {
+    } else if (current_token_ && current_token_->keyword_id == db25::Keyword::INSTEAD) {
         advance();
         if (current_token_ && current_token_->keyword_id == db25::Keyword::OF) {
             advance();
@@ -1349,7 +1349,7 @@ ast::ASTNode* Parser::parse_create_schema() {
     }
     
     // Optional AUTHORIZATION clause
-    if (current_token_ && current_token_->value == "AUTHORIZATION") {
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::AUTHORIZATION) {
         advance();
         if (current_token_ && current_token_->type == tokenizer::TokenType::Identifier) {
             schema_node->schema_name = copy_to_arena(current_token_->value); // Store owner in schema_name

--- a/src/parser/parser_dml.cpp
+++ b/src/parser/parser_dml.cpp
@@ -239,54 +239,31 @@ ast::ASTNode* Parser::parse_insert_stmt() {
         }
     }
     
-    // Optional ON CONFLICT clause (for UPSERT)
+    // Optional ON CONFLICT clause (for UPSERT). Delegate to the fully
+    // implemented helper, which parses the conflict target column list and the
+    // DO UPDATE SET assignments (the previous inline version stubbed both out).
     if (current_token_ && current_token_->keyword_id == db25::Keyword::ON) {
-        size_t save_pos = tokenizer_ ? tokenizer_->position() : 0;
-        const tokenizer::Token* save_token = current_token_;
-        
-        advance();  // consume ON
-        if (current_token_ && current_token_->value == "CONFLICT") {
-            advance();  // consume CONFLICT
-            
-            auto* on_conflict = arena_.allocate<ast::ASTNode>();
-            new (on_conflict) ast::ASTNode(ast::NodeType::OnConflictClause);
-            on_conflict->node_id = next_node_id_++;
-            
-            // Parse conflict target (optional)
-            if (current_token_ && current_token_->value == "(") {
-                // Parse column list for conflict target
-                // TODO: Implement conflict target parsing
-            }
-            
-            // Parse conflict action
-            if (current_token_ && current_token_->keyword_id == db25::Keyword::DO) {
-                advance();  // consume DO
-                
-                if (current_token_ && current_token_->value == "NOTHING") {
-                    advance();  // consume NOTHING
-                    on_conflict->semantic_flags |= 0x01;  // DO NOTHING flag
-                } else if (current_token_ && current_token_->keyword_id == db25::Keyword::UPDATE) {
-                    advance();  // consume UPDATE
-                    on_conflict->semantic_flags |= 0x02;  // DO UPDATE flag
-                    
-                    if (current_token_ && current_token_->keyword_id == db25::Keyword::SET) {
-                        advance();  // consume SET
-                        // Parse SET clauses
-                        // TODO: Implement SET clause parsing for ON CONFLICT DO UPDATE
-                    }
-                }
-            }
-            
+        auto* on_conflict = parse_on_conflict_clause();
+        if (on_conflict) {
             on_conflict->parent = insert_node;
             last_child->next_sibling = on_conflict;
+            last_child = on_conflict;
             insert_node->child_count++;
-        } else {
-            // Not ON CONFLICT, restore position
-            current_token_ = save_token;
-            if (tokenizer_) tokenizer_->set_position(save_pos);
         }
     }
-    
+
+    // Optional RETURNING clause (PostgreSQL extension). The helper already
+    // gates on keyword_id, so lowercase "returning" is honored.
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::RETURNING) {
+        auto* returning_clause = parse_returning_clause();
+        if (returning_clause) {
+            returning_clause->parent = insert_node;
+            last_child->next_sibling = returning_clause;
+            last_child = returning_clause;
+            insert_node->child_count++;
+        }
+    }
+
     return insert_node;
 }
 
@@ -422,7 +399,7 @@ ast::ASTNode* Parser::parse_update_stmt() {
     }
     
     // Optional RETURNING clause (PostgreSQL extension)
-    if (current_token_ && current_token_->value == "RETURNING") {
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::RETURNING) {
         advance();  // consume RETURNING
         
         auto* returning_clause = arena_.allocate<ast::ASTNode>();
@@ -505,7 +482,7 @@ ast::ASTNode* Parser::parse_delete_stmt() {
     ast::ASTNode* last_child = table_ref;
     
     // Optional USING clause (PostgreSQL extension)
-    if (current_token_ && current_token_->value == "USING") {
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::USING) {
         advance();  // consume USING
         
         auto* using_clause = arena_.allocate<ast::ASTNode>();
@@ -556,7 +533,7 @@ ast::ASTNode* Parser::parse_delete_stmt() {
     }
     
     // Optional RETURNING clause (PostgreSQL extension)
-    if (current_token_ && current_token_->value == "RETURNING") {
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::RETURNING) {
         advance();  // consume RETURNING
         
         auto* returning_clause = arena_.allocate<ast::ASTNode>();
@@ -611,7 +588,7 @@ ast::ASTNode* Parser::parse_delete_stmt() {
 
 ast::ASTNode* Parser::parse_returning_clause() {
     // RETURNING clause implementation
-    if (!current_token_ || current_token_->value != "RETURNING") {
+    if (!current_token_ || current_token_->keyword_id != db25::Keyword::RETURNING) {
         return nullptr;
     }
     advance();  // consume RETURNING
@@ -669,7 +646,7 @@ ast::ASTNode* Parser::parse_on_conflict_clause() {
     
     advance();  // consume ON
     
-    if (!current_token_ || current_token_->value != "CONFLICT") {
+    if (!current_token_ || current_token_->keyword_id != db25::Keyword::CONFLICT) {
         // Not ON CONFLICT, restore
         current_token_ = save_token;
         if (tokenizer_) tokenizer_->set_position(save_pos);
@@ -727,7 +704,7 @@ ast::ASTNode* Parser::parse_on_conflict_clause() {
     if (current_token_ && current_token_->keyword_id == db25::Keyword::DO) {
         advance();  // consume DO
         
-        if (current_token_ && current_token_->value == "NOTHING") {
+        if (current_token_ && current_token_->keyword_id == db25::Keyword::NOTHING) {
             advance();  // consume NOTHING
             on_conflict->semantic_flags |= 0x01;  // DO NOTHING flag
         } else if (current_token_ && current_token_->keyword_id == db25::Keyword::UPDATE) {
@@ -801,7 +778,7 @@ ast::ASTNode* Parser::parse_on_conflict_clause() {
 
 ast::ASTNode* Parser::parse_using_clause() {
     // USING clause for DELETE/UPDATE
-    if (!current_token_ || current_token_->value != "USING") {
+    if (!current_token_ || current_token_->keyword_id != db25::Keyword::USING) {
         return nullptr;
     }
     advance();  // consume USING

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1387,16 +1387,51 @@ ast::ASTNode* Parser::parse_table_reference() {
 
         ref_node = subquery_node;
     }
-    // Simple table name
+    // Simple table name, optionally schema/catalog qualified: "schema.table"
+    // (or "catalog.schema.table"). Read every dotted part, not just the first,
+    // otherwise the qualifier and everything after it (WHERE, etc.) is silently
+    // dropped -- a data-loss bug for statements like DELETE.
     else if (current_token_->type == tokenizer::TokenType::Identifier) {
         auto* table_node = arena_.allocate<ast::ASTNode>();
         new (table_node) ast::ASTNode(ast::NodeType::TableRef);
         table_node->node_id = next_node_id_++;
 
-        // Store table name
-        table_node->primary_text = copy_to_arena(current_token_->value);
-
+        // Collect the dotted parts of the qualified table name. The tokenizer
+        // may classify "." as Operator or Delimiter (see parse_column_ref).
+        std::vector<std::string_view> parts;
+        parts.push_back(current_token_->value);
         advance();
+        while (current_token_ &&
+               (current_token_->type == tokenizer::TokenType::Delimiter ||
+                current_token_->type == tokenizer::TokenType::Operator) &&
+               current_token_->value == "." &&
+               peek_token_ &&
+               (peek_token_->type == tokenizer::TokenType::Identifier ||
+                peek_token_->type == tokenizer::TokenType::Keyword)) {
+            advance();  // consume '.'
+            parts.push_back(current_token_->value);
+            advance();  // consume the identifier after the dot
+        }
+
+        // FIELD REPRESENTATION (must stay consistent with the semantic
+        // analyzer, whose alias_of() reads schema_name as the ALIAS):
+        //   - primary_text : the (unqualified) table name        -> last part
+        //   - catalog_name : the schema/catalog qualifier(s)     -> earlier parts
+        //   - schema_name  : RESERVED for the table alias, set below; NEVER the
+        //                    schema qualifier (that would clobber the alias).
+        // catalog_name is chosen because get_qualified_name() already emits it
+        // ahead of the table name, and it does not collide with the alias slot.
+        table_node->primary_text = copy_to_arena(parts.back());
+        if (parts.size() > 1) {
+            std::string qualifier;
+            for (size_t i = 0; i + 1 < parts.size(); ++i) {
+                if (i > 0) qualifier += '.';
+                qualifier += parts[i];
+            }
+            table_node->catalog_name = copy_to_arena(qualifier);
+            // has_catalog() keys off catalog_name being non-empty; no flag needed.
+        }
+
         ref_node = table_node;
     }
 

--- a/src/parser/parser_statements.cpp
+++ b/src/parser/parser_statements.cpp
@@ -82,7 +82,7 @@ ast::ASTNode* Parser::parse_transaction_stmt() {
             advance(); // consume TO
             
             // Optional SAVEPOINT keyword
-            if (current_token_ && current_token_->value == "SAVEPOINT") {
+            if (current_token_ && current_token_->keyword_id == db25::Keyword::SAVEPOINT) {
                 advance(); // consume SAVEPOINT
             }
             
@@ -120,7 +120,7 @@ ast::ASTNode* Parser::parse_transaction_stmt() {
         advance(); // consume RELEASE
         
         // Optional SAVEPOINT keyword
-        if (current_token_ && current_token_->value == "SAVEPOINT") {
+        if (current_token_ && current_token_->keyword_id == db25::Keyword::SAVEPOINT) {
             advance(); // consume SAVEPOINT
         }
         

--- a/tests/test_parser_correctness_round2.cpp
+++ b/tests/test_parser_correctness_round2.cpp
@@ -1,0 +1,173 @@
+/*
+ * DB25 Parser - Correctness Round 2 Regression Tests
+ *
+ * Covers four parser-correctness fixes:
+ *   1. Schema-qualified table names (schema.table [alias]) with all trailing
+ *      clauses retained (previously a data-loss bug).
+ *   2. Trailing-input detection surfaced as a queryable diagnostic.
+ *   3. Case-insensitive DML keyword gating (lowercase RETURNING, etc.).
+ *   4. INSERT RETURNING and ON CONFLICT wired to the real clause helpers.
+ */
+
+#include <gtest/gtest.h>
+#include "db25/parser/parser.hpp"
+#include "db25/ast/ast_node.hpp"
+
+using namespace db25;
+using namespace db25::parser;
+using namespace db25::ast;
+
+namespace {
+
+class CorrectnessRound2Test : public ::testing::Test {
+protected:
+    Parser parser;
+
+    ASTNode* parse(const std::string& sql) {
+        auto result = parser.parse(sql);
+        return result.has_value() ? result.value() : nullptr;
+    }
+
+    static ASTNode* find_child(ASTNode* node, NodeType type) {
+        for (auto* c = node ? node->first_child : nullptr; c; c = c->next_sibling) {
+            if (c->node_type == type) return c;
+        }
+        return nullptr;
+    }
+};
+
+// ============================================================================
+// Fix 1: schema-qualified table names
+// ============================================================================
+// Field representation contract (also enforced against the semantic analyzer):
+//   primary_text = table name, schema_name = alias, catalog_name = schema.
+
+TEST_F(CorrectnessRound2Test, SchemaQualifiedSelectRetainsAliasAndWhere) {
+    auto* ast = parse("SELECT * FROM public.users u WHERE u.id=1");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::SelectStmt);
+
+    auto* from = find_child(ast, NodeType::FromClause);
+    ASSERT_NE(from, nullptr);
+    auto* table = from->first_child;
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table->node_type, NodeType::TableRef);
+    EXPECT_EQ(table->primary_text, "users");   // table name
+    EXPECT_EQ(table->catalog_name, "public");  // schema qualifier
+    EXPECT_EQ(table->schema_name, "u");         // alias slot (analyzer reads this)
+
+    // The WHERE clause must survive the qualified table name.
+    ASSERT_NE(find_child(ast, NodeType::WhereClause), nullptr);
+}
+
+TEST_F(CorrectnessRound2Test, SchemaQualifiedDeleteRetainsSchemaAndWhere) {
+    // Data-loss regression: DELETE FROM public.users WHERE id=1 previously
+    // dropped ".users" and the entire WHERE, becoming an unbounded delete.
+    auto* ast = parse("DELETE FROM public.users WHERE id=1");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::DeleteStmt);
+
+    auto* table = ast->first_child;
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table->node_type, NodeType::TableRef);
+    EXPECT_EQ(table->primary_text, "users");
+    EXPECT_EQ(table->catalog_name, "public");
+
+    ASSERT_NE(find_child(ast, NodeType::WhereClause), nullptr);
+}
+
+TEST_F(CorrectnessRound2Test, UnqualifiedTableUnaffected) {
+    auto* ast = parse("SELECT * FROM users WHERE id=1");
+    ASSERT_NE(ast, nullptr);
+    auto* from = find_child(ast, NodeType::FromClause);
+    ASSERT_NE(from, nullptr);
+    auto* table = from->first_child;
+    ASSERT_NE(table, nullptr);
+    EXPECT_EQ(table->primary_text, "users");
+    EXPECT_TRUE(table->catalog_name.empty());
+    ASSERT_NE(find_child(ast, NodeType::WhereClause), nullptr);
+}
+
+// ============================================================================
+// Fix 2: trailing-input detection (lenient, queryable)
+// ============================================================================
+
+TEST_F(CorrectnessRound2Test, TrailingInputIsFlagged) {
+    auto result = parser.parse("SELECT * FROM t WHERE x=1 EXTRA STUFF HERE");
+    ASSERT_TRUE(result.has_value());  // still lenient success
+    EXPECT_TRUE(parser.has_trailing_input());
+    EXPECT_GT(parser.trailing_token_count(), 0u);
+}
+
+TEST_F(CorrectnessRound2Test, NoTrailingInputForCleanStatement) {
+    auto result = parser.parse("SELECT * FROM t WHERE x=1");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(parser.has_trailing_input());
+    EXPECT_EQ(parser.trailing_token_count(), 0u);
+}
+
+TEST_F(CorrectnessRound2Test, TrailingSemicolonNotCountedAsTrailingInput) {
+    auto result = parser.parse("SELECT * FROM t;");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(parser.has_trailing_input());
+}
+
+// ============================================================================
+// Fix 3: case-insensitive DML keyword gating
+// ============================================================================
+
+TEST_F(CorrectnessRound2Test, LowercaseUpdateReturning) {
+    auto* ast = parse("update t set a=1 returning *");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::UpdateStmt);
+    ASSERT_NE(find_child(ast, NodeType::ReturningClause), nullptr);
+}
+
+TEST_F(CorrectnessRound2Test, LowercaseDeleteReturning) {
+    auto* ast = parse("delete from t returning id");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::DeleteStmt);
+    ASSERT_NE(find_child(ast, NodeType::ReturningClause), nullptr);
+}
+
+// ============================================================================
+// Fix 4: INSERT RETURNING and ON CONFLICT wired to real helpers
+// ============================================================================
+
+TEST_F(CorrectnessRound2Test, InsertReturning) {
+    auto* ast = parse("INSERT INTO t (a) VALUES (1) RETURNING *");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::InsertStmt);
+    auto* ret = find_child(ast, NodeType::ReturningClause);
+    ASSERT_NE(ret, nullptr);
+    ASSERT_NE(ret->first_child, nullptr);
+    EXPECT_EQ(ret->first_child->node_type, NodeType::Star);
+}
+
+TEST_F(CorrectnessRound2Test, InsertOnConflictTargetAndSet) {
+    auto* ast = parse("INSERT INTO t (a) VALUES (1) ON CONFLICT (a) DO UPDATE SET a=2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::InsertStmt);
+
+    auto* on_conflict = find_child(ast, NodeType::OnConflictClause);
+    ASSERT_NE(on_conflict, nullptr);
+
+    // Conflict target column "a" must be present.
+    auto* target = find_child(on_conflict, NodeType::Identifier);
+    ASSERT_NE(target, nullptr);
+    EXPECT_EQ(target->primary_text, "a");
+
+    // DO UPDATE SET must be populated.
+    auto* set_clause = find_child(on_conflict, NodeType::SetClause);
+    ASSERT_NE(set_clause, nullptr);
+    ASSERT_NE(set_clause->first_child, nullptr);
+    EXPECT_EQ(set_clause->first_child->primary_text, "a");
+}
+
+TEST_F(CorrectnessRound2Test, InsertOnConflictDoNothing) {
+    auto* ast = parse("INSERT INTO t (a) VALUES (1) ON CONFLICT DO NOTHING");
+    ASSERT_NE(ast, nullptr);
+    ASSERT_NE(find_child(ast, NodeType::OnConflictClause), nullptr);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Four high-value parser correctness fixes from the pre-execution review. Verified Release + ASan/UBSan (36 suites, 0 failures); tokenizer submodule untouched.

**1. Schema-qualified table names — data-loss fix.** `parse_table_reference()` read one identifier and stopped, so `DELETE FROM public.users WHERE id=1` dropped `.users` **and the entire WHERE** and returned *success* (unbounded-delete class); `SELECT * FROM public.users WHERE …` lost the WHERE. It now reads all dotted parts (`schema.table`, `catalog.schema.table`) + optional alias and lets the caller continue with WHERE/etc.
   - **Field representation (analyzer-compatible by design):** `primary_text` = table name; **`schema_name` = alias, unchanged** (this is what the analyzer's `alias_of()` reads); schema qualifier goes in **`catalog_name`** (consistent with `get_qualified_name()`, keyed by `has_catalog()`, no collision with the alias slot).

**2. Trailing-input detection (non-fatal).** `parse()` returned success even with tokens left after the statement. The parser is intentionally lenient (a prior hard-reject was reverted), so this is exposed as a **queryable diagnostic** — `has_trailing_input()` / `trailing_token_count()` — not a parse failure. All existing lenient tests stay green.

**3. Case-insensitive keyword gating.** DML clauses were gated on exact-uppercase `value == "RETURNING"/"CONFLICT"/"USING"/"NOTHING"` (+ RENAME/INSTEAD/AUTHORIZATION/SAVEPOINT), so lowercase SQL dropped them. Now compares `keyword_id`.

**4. INSERT RETURNING / ON CONFLICT wired.** `parse_insert_stmt()` used a stubbed inline ON CONFLICT and had no RETURNING, while fully-implemented `parse_on_conflict_clause()` / `parse_returning_clause()` sat dead. Now wired in. `INSERT … RETURNING *` produces a `ReturningClause`; `INSERT … ON CONFLICT (a) DO UPDATE SET a=2` produces a populated `OnConflictClause`.

## Tests

New `test_parser_correctness_round2` (11 cases). **35 → 36 suites**, 0 failures, ASan/UBSan clean.