### PR TITLE
parser: parse NATURAL JOIN instead of dropping it

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -676,7 +676,8 @@ ast::ASTNode* Parser::parse_from_clause() {
                            kw == "RIGHT" || kw == "right" ||
                            kw == "INNER" || kw == "inner" ||
                            kw == "FULL" || kw == "full" ||
-                           kw == "CROSS" || kw == "cross");
+                           kw == "CROSS" || kw == "cross" ||
+                           kw == "NATURAL" || kw == "natural");
             
             if (is_join) {
                 auto* join_clause = parse_join_clause();
@@ -710,7 +711,17 @@ ast::ASTNode* Parser::parse_join_clause() {
     // Store JOIN type (LEFT, RIGHT, INNER, etc.)
     std::string join_type;
     
-    // Handle JOIN type prefixes (LEFT, RIGHT, INNER, FULL, CROSS)
+    // Optional NATURAL prefix: NATURAL [INNER | LEFT [OUTER] | RIGHT [OUTER] |
+    // FULL [OUTER]] JOIN. A NATURAL join carries no ON / USING clause; its join
+    // columns are every column common to both inputs, resolved downstream.
+    if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+        current_token_->keyword_id == db25::Keyword::NATURAL) {
+        join_type = "NATURAL";
+        advance(); // consume NATURAL
+    }
+
+    // Handle JOIN type prefixes (LEFT, RIGHT, INNER, FULL, CROSS), which may
+    // follow a NATURAL prefix (NATURAL LEFT JOIN).
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
         const auto& kw = current_token_->value;
         if (kw == "LEFT" || kw == "left" ||
@@ -718,9 +729,12 @@ ast::ASTNode* Parser::parse_join_clause() {
             kw == "INNER" || kw == "inner" ||
             kw == "FULL" || kw == "full" ||
             kw == "CROSS" || kw == "cross") {
-            join_type = kw;
+            if (!join_type.empty()) {
+                join_type += " ";
+            }
+            join_type += kw;
             advance(); // consume JOIN type
-            
+
             // Also handle OUTER keyword (LEFT OUTER JOIN)
             if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
                 current_token_->keyword_id == db25::Keyword::OUTER) {

--- a/tests/test_join_comprehensive.cpp
+++ b/tests/test_join_comprehensive.cpp
@@ -101,11 +101,41 @@ TEST_F(JoinComprehensiveTest, FullOuterJoin) {
 TEST_F(JoinComprehensiveTest, CrossJoin) {
     auto* ast = parse("SELECT * FROM users CROSS JOIN orders");
     ASSERT_NE(ast, nullptr);
-    
+
     auto* join = find_node_by_type(ast, NodeType::JoinClause);
     ASSERT_NE(join, nullptr);
     EXPECT_EQ(join->primary_text, "CROSS JOIN");
     EXPECT_EQ(join->child_count, 1); // only table, no ON condition
+}
+
+TEST_F(JoinComprehensiveTest, NaturalJoin) {
+    // Regression: NATURAL JOIN was previously dropped entirely (the join clause
+    // and its right relation never reached the AST). It must now parse to a
+    // JoinClause carrying only the right table (no ON / USING - the join columns
+    // are the common columns, resolved downstream).
+    auto* ast = parse("SELECT id FROM users NATURAL JOIN orders");
+    ASSERT_NE(ast, nullptr);
+
+    auto* join = find_node_by_type(ast, NodeType::JoinClause);
+    ASSERT_NE(join, nullptr);
+    EXPECT_EQ(join->primary_text, "NATURAL JOIN");
+    EXPECT_EQ(join->child_count, 1); // only the right table
+
+    auto* rel = join->first_child;
+    ASSERT_NE(rel, nullptr);
+    EXPECT_EQ(rel->node_type, NodeType::TableRef);
+    EXPECT_EQ(rel->primary_text, "orders");
+}
+
+TEST_F(JoinComprehensiveTest, NaturalLeftJoin) {
+    // NATURAL composes with an outer-join prefix: NATURAL LEFT JOIN.
+    auto* ast = parse("SELECT id FROM users NATURAL LEFT JOIN orders");
+    ASSERT_NE(ast, nullptr);
+
+    auto* join = find_node_by_type(ast, NodeType::JoinClause);
+    ASSERT_NE(join, nullptr);
+    EXPECT_EQ(join->primary_text, "NATURAL LEFT JOIN");
+    EXPECT_EQ(join->child_count, 1);
 }
 
 TEST_F(JoinComprehensiveTest, MultipleJoins) {


### PR DESCRIPTION
## Problem

`SELECT … FROM a NATURAL JOIN b` silently lost the join **and its right relation** — the AST kept only the left table. The FROM-clause loop only recognized `JOIN` / `LEFT` / `RIGHT` / `INNER` / `FULL` / `CROSS` as join-starting keywords, so a leading `NATURAL` was treated as "not a join": the loop stopped and the rest of the join was never parsed. (Found by the DB25 end-to-end harness, where `NATURAL JOIN … == USING(id)` could not even be exercised.)

## Fix

- Recognize `NATURAL` as a join-starting keyword in the FROM loop.
- Consume an optional `NATURAL` prefix in `parse_join_clause` **before** the `LEFT`/`RIGHT`/`INNER`/`FULL`/`CROSS` prefix, so `NATURAL JOIN` and `NATURAL LEFT JOIN` produce a `JoinClause` whose `primary_text` records the type (`"NATURAL JOIN"`, `"NATURAL LEFT JOIN"`) with the right relation as its child.

A `NATURAL` join carries no `ON` / `USING` clause — its join columns are the columns common to both inputs, resolved downstream. The tokenizer already emits `Keyword::NATURAL`, so this is a **pure parser change** (the tokenizer is untouched).

## Tests

`NaturalJoin` and `NaturalLeftJoin` in `test_join_comprehensive` assert the `JoinClause` type and that the right table (`orders`) survives. All join/parser tests pass; the one unrelated `ArenaEdgeTest` failure is **pre-existing on `main`** (verified by stashing this change).

## Downstream note

This makes the AST faithful to the query. Making a `NATURAL` join execute like `USING(<common columns>)` is a separate binder/analyzer change (in `db25-logical-plan`) — the parser fix is the prerequisite.