### PR TITLE
parser: parse single-bound window frames (ROWS/RANGE/GROUPS &lt;bound&gt;)

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1838,20 +1838,94 @@ ast::ASTNode* Parser::parse_window_spec() {
         }
     }
     
-    // Parse frame clause (ROWS/RANGE BETWEEN ... AND ...)
+    // Parse frame clause: ROWS/RANGE/GROUPS { BETWEEN <bound> AND <bound> |
+    // <bound> }. A frame unit may be followed by BETWEEN (two bounds) or by a
+    // single bound (shorthand for BETWEEN <bound> AND CURRENT ROW).
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         (current_token_->keyword_id == db25::Keyword::ROWS ||
-         current_token_->keyword_id == db25::Keyword::RANGE)) {
-        
+         current_token_->keyword_id == db25::Keyword::RANGE ||
+         current_token_->keyword_id == db25::Keyword::GROUPS)) {
+
         auto* frame_node = arena_.allocate<ast::ASTNode>();
         new (frame_node) ast::ASTNode(ast::NodeType::FrameClause);
         frame_node->node_id = next_node_id_++;
         frame_node->parent = window_spec;
-        
+
         // Store frame type (ROWS or RANGE)
         frame_node->primary_text = copy_to_arena(current_token_->value);
         advance(); // consume ROWS/RANGE
-        
+
+        // Parse a single frame bound (UNBOUNDED PRECEDING/FOLLOWING, CURRENT
+        // ROW, <n> PRECEDING/FOLLOWING, or an INTERVAL bound). Shared by the
+        // single-bound frame form below; the BETWEEN form keeps its own inline
+        // parsing unchanged.
+        auto parse_frame_bound = [&]() -> ast::ASTNode* {
+            auto* bound = arena_.allocate<ast::ASTNode>();
+            new (bound) ast::ASTNode(ast::NodeType::FrameBound);
+            bound->node_id = next_node_id_++;
+            bound->parent = frame_node;
+
+            if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                current_token_->keyword_id == db25::Keyword::UNBOUNDED) {
+                bound->primary_text = copy_to_arena("UNBOUNDED");
+                advance(); // consume UNBOUNDED
+                if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                    current_token_->keyword_id == db25::Keyword::PRECEDING) {
+                    bound->primary_text = copy_to_arena("UNBOUNDED PRECEDING");
+                    bound->semantic_flags |= ast::FrameBoundPreceding;
+                    advance(); // consume PRECEDING
+                } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                           current_token_->keyword_id == db25::Keyword::FOLLOWING) {
+                    bound->primary_text = copy_to_arena("UNBOUNDED FOLLOWING");
+                    bound->semantic_flags |= ast::FrameBoundFollowing;
+                    advance(); // consume FOLLOWING
+                }
+            } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                       current_token_->keyword_id == db25::Keyword::CURRENT) {
+                advance(); // consume CURRENT
+                if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                    current_token_->keyword_id == db25::Keyword::ROW) {
+                    bound->primary_text = copy_to_arena("CURRENT ROW");
+                    advance(); // consume ROW
+                }
+            } else if (current_token_) {
+                if (current_token_->type == tokenizer::TokenType::Number) {
+                    bound->primary_text = copy_to_arena(current_token_->value);
+                    advance(); // consume number
+                } else if (current_token_->value == "INTERVAL" || current_token_->value == "interval") {
+                    advance(); // consume INTERVAL
+                    if (current_token_ && current_token_->type == tokenizer::TokenType::String) {
+                        std::string interval_expr = "INTERVAL ";
+                        interval_expr += std::string(current_token_->value);
+                        bound->primary_text = copy_to_arena(interval_expr);
+                        advance();
+                    }
+                    if (current_token_ && (current_token_->type == tokenizer::TokenType::Keyword ||
+                                           current_token_->type == tokenizer::TokenType::Identifier)) {
+                        std::string interval_text = bound->primary_text.empty() ? "INTERVAL" : std::string(bound->primary_text);
+                        interval_text += " ";
+                        interval_text += std::string(current_token_->value);
+                        bound->primary_text = copy_to_arena(interval_text);
+                        advance();
+                    }
+                }
+                if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
+                    if (current_token_->keyword_id == db25::Keyword::PRECEDING) {
+                        bound->primary_text =
+                            copy_to_arena(std::string(bound->primary_text) + " PRECEDING");
+                        bound->semantic_flags |= ast::FrameBoundPreceding;
+                        advance();
+                    } else if (current_token_->keyword_id == db25::Keyword::FOLLOWING) {
+                        bound->primary_text =
+                            copy_to_arena(std::string(bound->primary_text) + " FOLLOWING");
+                        bound->semantic_flags |= ast::FrameBoundFollowing;
+                        advance();
+                    }
+                }
+            }
+            return bound;
+        };
+
         // Parse BETWEEN clause
         if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
             current_token_->keyword_id == db25::Keyword::BETWEEN) {
@@ -2010,8 +2084,18 @@ ast::ASTNode* Parser::parse_window_spec() {
                 frame_start->next_sibling = frame_end;
                 frame_node->child_count++;
             }
+        } else {
+            // Single-bound frame: ROWS/RANGE/GROUPS <bound> without BETWEEN,
+            // e.g. ROWS UNBOUNDED PRECEDING, ROWS 5 PRECEDING, RANGE CURRENT
+            // ROW. Parse exactly one bound so the frame-bound tokens are
+            // consumed and the closing ')' is reached (otherwise parenthesis
+            // tracking is left elevated and the parse fails as "Unclosed
+            // parenthesis").
+            auto* frame_bound = parse_frame_bound();
+            frame_node->first_child = frame_bound;
+            frame_node->child_count = 1;
         }
-        
+
         // Add frame node to window spec
         if (!window_spec->first_child) {
             window_spec->first_child = frame_node;

--- a/tests/test_parser_fixes_phase2.cpp
+++ b/tests/test_parser_fixes_phase2.cpp
@@ -342,3 +342,84 @@ TEST_F(ParserFixesPhase2Test, MixedFrameTypes) {
         EXPECT_GE(rows_frames + range_frames, 1) << "Should find at least one frame specification";
     }
 }
+// Helper: count FrameBound descendants of a node.
+static int count_frame_bounds(ASTNode* n) {
+    if (!n) return 0;
+    int c = (n->node_type == NodeType::FrameBound) ? 1 : 0;
+    for (auto* ch = n->first_child; ch; ch = ch->next_sibling) {
+        c += count_frame_bounds(ch);
+    }
+    return c;
+}
+
+// Regression: a single-bound window frame (no BETWEEN) previously failed to
+// parse with "Unclosed parenthesis" because frame-bound parsing was nested
+// entirely under the BETWEEN branch, so the bound tokens and the closing ')'
+// were never consumed. Unlike MixedFrameTypes above, these assertions are
+// UNCONDITIONAL: the parse MUST succeed.
+TEST_F(ParserFixesPhase2Test, SingleBoundFrameUnboundedPreceding) {
+    std::string sql = "SELECT SUM(x) OVER (ORDER BY a ROWS UNBOUNDED PRECEDING) FROM t";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value())
+        << "single-bound ROWS UNBOUNDED PRECEDING frame must parse";
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* frame = find_node_type(result.value(), NodeType::FrameClause);
+    ASSERT_NE(frame, nullptr) << "should produce a FrameClause";
+    EXPECT_EQ(frame->primary_text, "ROWS");
+    EXPECT_EQ(count_frame_bounds(frame), 1) << "single-bound frame has one bound";
+
+    auto* bound = find_node_type(frame, NodeType::FrameBound);
+    ASSERT_NE(bound, nullptr);
+    EXPECT_EQ(bound->primary_text, "UNBOUNDED PRECEDING");
+}
+
+TEST_F(ParserFixesPhase2Test, SingleBoundFrameNPreceding) {
+    std::string sql = "SELECT SUM(x) OVER (ORDER BY a ROWS 5 PRECEDING) FROM t";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value()) << "single-bound ROWS 5 PRECEDING must parse";
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* frame = find_node_type(result.value(), NodeType::FrameClause);
+    ASSERT_NE(frame, nullptr);
+    EXPECT_EQ(frame->primary_text, "ROWS");
+    EXPECT_EQ(count_frame_bounds(frame), 1);
+
+    auto* bound = find_node_type(frame, NodeType::FrameBound);
+    ASSERT_NE(bound, nullptr);
+    EXPECT_EQ(bound->primary_text, "5 PRECEDING");
+}
+
+TEST_F(ParserFixesPhase2Test, SingleBoundFrameRangeCurrentRow) {
+    std::string sql = "SELECT SUM(x) OVER (ORDER BY a RANGE CURRENT ROW) FROM t";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value()) << "single-bound RANGE CURRENT ROW must parse";
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* frame = find_node_type(result.value(), NodeType::FrameClause);
+    ASSERT_NE(frame, nullptr);
+    EXPECT_EQ(frame->primary_text, "RANGE");
+    EXPECT_EQ(count_frame_bounds(frame), 1);
+
+    auto* bound = find_node_type(frame, NodeType::FrameBound);
+    ASSERT_NE(bound, nullptr);
+    EXPECT_EQ(bound->primary_text, "CURRENT ROW");
+}
+
+// Control: the two-bound BETWEEN form must keep working (two FrameBounds).
+TEST_F(ParserFixesPhase2Test, TwoBoundBetweenFrameStillParses) {
+    std::string sql =
+        "SELECT SUM(x) OVER (ORDER BY a ROWS BETWEEN UNBOUNDED PRECEDING "
+        "AND CURRENT ROW) FROM t";
+
+    auto result = parser.parse(sql);
+    ASSERT_TRUE(result.has_value()) << "two-bound BETWEEN frame must parse";
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* frame = find_node_type(result.value(), NodeType::FrameClause);
+    ASSERT_NE(frame, nullptr);
+    EXPECT_EQ(count_frame_bounds(frame), 2) << "BETWEEN frame has two bounds";
+}


### PR DESCRIPTION
## Problem

A window frame with a single bound (no `BETWEEN`) failed to parse and corrupted paren tracking:

```sql
SELECT SUM(x) OVER (ORDER BY a ROWS UNBOUNDED PRECEDING) FROM t
→ PARSE ERROR: Unclosed parenthesis
```

`ROWS 5 PRECEDING`, `ROWS CURRENT ROW`, `RANGE UNBOUNDED PRECEDING` — all standard SQL — failed the same way. Frame-bound parsing was nested entirely under the `if (BETWEEN)` branch, so without `BETWEEN` the bound tokens were never consumed, the closing `)` was never reached, and `parenthesis_depth_` stayed elevated.

## Fix

Factor single frame-bound parsing into a `parse_frame_bound` helper (covers `UNBOUNDED PRECEDING/FOLLOWING`, `CURRENT ROW`, `<n> PRECEDING/FOLLOWING`, `INTERVAL` bounds) and add an `else` branch that parses exactly one bound and builds a `FrameClause` with one `FrameBound`. The two-bound `BETWEEN` path is unchanged. Also recognizes `GROUPS` alongside `ROWS`/`RANGE` as a frame unit.

## Tests

New in `test_parser_fixes_phase2.cpp`: `SingleBoundFrameUnboundedPreceding`, `SingleBoundFrameNPreceding`, `SingleBoundFrameRangeCurrentRow` (each asserts `has_value()` **unconditionally** + one `FrameBound`), and a `TwoBoundBetweenFrameStillParses` control. (The pre-existing `MixedFrameTypes` test passed *vacuously* via an `if (result.has_value())` guard — the new tests assert unconditionally.)

Full parser/AST/CTE/set-op/window suites pass. Verified end-to-end: `OVER (ORDER BY id ROWS UNBOUNDED PRECEDING)` now parses, analyzes, and binds, and the `BETWEEN … AND …` form still binds.