### PR TITLE
parser: parse a parenthesized join group in FROM

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1411,42 +1411,74 @@ ast::ASTNode* Parser::parse_table_reference() {
 
     ast::ASTNode* ref_node = nullptr;
 
-    // Derived table: ( SELECT ... ) or ( WITH ... ) with a required alias.
-    // Only treat '(' as a table reference when it introduces a subquery; a
-    // plain grouped expression is not valid in a FROM/JOIN position here.
+    // A '(' in table-reference position introduces either a derived table
+    // ( SELECT ... ) / ( WITH ... ), or a parenthesized join group such as
+    // ( a JOIN b ON a.id = b.id ). Disambiguate on the following token.
     if (current_token_->type == tokenizer::TokenType::Delimiter &&
-        current_token_->value == "(" &&
-        peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
-        (peek_token_->keyword_id == db25::Keyword::SELECT ||
-         peek_token_->keyword_id == db25::Keyword::WITH)) {
-        advance();               // consume '('
-        parenthesis_depth_++;
+        current_token_->value == "(") {
+        const bool is_derived_table =
+            peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
+            (peek_token_->keyword_id == db25::Keyword::SELECT ||
+             peek_token_->keyword_id == db25::Keyword::WITH);
+        // A parenthesized join group begins with something that itself begins a
+        // table reference: an identifier (table name) or a nested '('.
+        const bool is_join_group =
+            !is_derived_table && peek_token_ &&
+            (peek_token_->type == tokenizer::TokenType::Identifier ||
+             (peek_token_->type == tokenizer::TokenType::Delimiter &&
+              peek_token_->value == "("));
 
-        auto* subquery_node = arena_.allocate<ast::ASTNode>();
-        new (subquery_node) ast::ASTNode(ast::NodeType::Subquery);
-        subquery_node->node_id = next_node_id_++;
-        subquery_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::IsSubquery);
+        if (is_derived_table) {
+            advance();               // consume '('
+            parenthesis_depth_++;
 
-        push_context(ParseContext::SUBQUERY);
-        auto* inner = (current_token_ &&
-                       current_token_->type == tokenizer::TokenType::Keyword &&
-                       current_token_->keyword_id == db25::Keyword::WITH)
-                          ? parse_with_statement()
-                          : parse_select_stmt();
-        pop_context();
-        if (inner) {
-            inner->parent = subquery_node;
-            subquery_node->first_child = inner;
-            subquery_node->child_count = 1;
+            auto* subquery_node = arena_.allocate<ast::ASTNode>();
+            new (subquery_node) ast::ASTNode(ast::NodeType::Subquery);
+            subquery_node->node_id = next_node_id_++;
+            subquery_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::IsSubquery);
+
+            push_context(ParseContext::SUBQUERY);
+            auto* inner = (current_token_ &&
+                           current_token_->type == tokenizer::TokenType::Keyword &&
+                           current_token_->keyword_id == db25::Keyword::WITH)
+                              ? parse_with_statement()
+                              : parse_select_stmt();
+            pop_context();
+            if (inner) {
+                inner->parent = subquery_node;
+                subquery_node->first_child = inner;
+                subquery_node->child_count = 1;
+            }
+
+            // Consume closing ')'
+            if (current_token_ && current_token_->value == ")") {
+                if (parenthesis_depth_ > 0) parenthesis_depth_--;
+                advance();
+            }
+
+            ref_node = subquery_node;
+        } else if (is_join_group) {
+            // Parenthesized join group: ( <table-ref> [ <join> ]* ). Parse the
+            // inner join tree by reusing the FROM-item / join chaining logic
+            // (parse_from_clause -> parse_table_reference + parse_join_clause),
+            // then consume the matching ')'. The resulting FromClause node
+            // stands in as a single table reference so the caller can attach it
+            // and continue parsing any trailing joins on the group.
+            advance();               // consume '('
+            parenthesis_depth_++;
+
+            auto* group = parse_from_clause();
+
+            // Consume closing ')'
+            if (current_token_ && current_token_->value == ")") {
+                if (parenthesis_depth_ > 0) parenthesis_depth_--;
+                advance();
+            }
+
+            ref_node = group;
         }
-
-        // Consume closing ')'
-        if (current_token_ && current_token_->value == ")") {
-            if (parenthesis_depth_ > 0) parenthesis_depth_--;
-            advance();
-        }
-
-        ref_node = subquery_node;
+        // Otherwise (a bare '(' that is neither): leave it unconsumed and fall
+        // through to return nullptr, preserving the prior behaviour.
     }
     // Simple table name, optionally schema/catalog qualified: "schema.table"
     // (or "catalog.schema.table"). Read every dotted part, not just the first,

--- a/tests/test_parser_select.cpp
+++ b/tests/test_parser_select.cpp
@@ -561,3 +561,65 @@ TEST_F(SelectParserTest, DistinctWithStar) {
     auto* star = find_child_by_type(select_list, NodeType::Star);
     ASSERT_NE(star, nullptr);
 }
+// ===== Parenthesized JOIN group in FROM position =====
+// Regression: `FROM (a JOIN b ON ...) JOIN c ON ...` previously dropped the
+// whole FROM clause (parse_table_reference did not recognise a parenthesized
+// join group, so parse_from_clause returned nullptr with FROM consumed and the
+// remainder of the statement became trailing input).
+
+namespace {
+// Recursively count nodes of a given type anywhere in the subtree.
+int count_nodes_of_type(ASTNode* n, NodeType t) {
+    if (!n) return 0;
+    int c = (n->node_type == t) ? 1 : 0;
+    for (auto* ch = n->first_child; ch; ch = ch->next_sibling) {
+        c += count_nodes_of_type(ch, t);
+    }
+    return c;
+}
+}  // namespace
+
+TEST_F(SelectParserTest, ParenthesizedJoinGroupInFrom) {
+    auto result = parser.parse(
+        "SELECT * FROM (a JOIN b ON a.id=b.id) JOIN c ON a.id=c.id");
+    ASSERT_TRUE(result.has_value()) << "parenthesized join group should parse";
+
+    // No input may be dropped: the entire FROM clause must be consumed.
+    EXPECT_FALSE(parser.has_trailing_input());
+    EXPECT_EQ(parser.trailing_token_count(), 0u);
+
+    auto* ast = result.value();
+    auto* from = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from, nullptr) << "SELECT must have a FROM clause";
+
+    // The FROM clause holds the parenthesized group (itself a nested join tree)
+    // plus the trailing `JOIN c`. Overall there must be two JoinClause nodes:
+    // the inner `JOIN b` and the outer `JOIN c`.
+    EXPECT_EQ(count_nodes_of_type(from, NodeType::JoinClause), 2);
+
+    // Three base tables (a, b, c) are referenced.
+    EXPECT_EQ(count_nodes_of_type(from, NodeType::TableRef), 3);
+
+    // The nested group is represented as a FromClause nested inside the outer
+    // FROM clause, containing table `a` and the `JOIN b` clause.
+    auto* nested = find_child_by_type(from, NodeType::FromClause);
+    ASSERT_NE(nested, nullptr) << "nested join group should be present";
+    EXPECT_EQ(count_nodes_of_type(nested, NodeType::JoinClause), 1);
+    EXPECT_NE(find_child_by_type(nested, NodeType::TableRef), nullptr);
+}
+
+TEST_F(SelectParserTest, DerivedTableStillParsesAsSubquery) {
+    // Control: a `( SELECT ... ) alias` must remain a derived table (Subquery),
+    // not be mistaken for a parenthesized join group.
+    auto result = parser.parse("SELECT * FROM (SELECT 1) x");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* ast = result.value();
+    auto* from = find_child_by_type(ast, NodeType::FromClause);
+    ASSERT_NE(from, nullptr);
+
+    auto* subquery = find_child_by_type(from, NodeType::Subquery);
+    ASSERT_NE(subquery, nullptr) << "derived table must parse as a Subquery";
+    EXPECT_EQ(subquery->schema_name, "x");  // alias preserved
+}


### PR DESCRIPTION
## Problem

A parenthesized join group in `FROM` silently dropped the **entire** FROM clause:

```sql
SELECT * FROM (a JOIN b ON a.id=b.id) JOIN c ON a.id=c.id
→ parse "success", but the SelectStmt has NO FromClause (all 23 trailing tokens ignored)
```

`parse_table_reference` treated a leading `(` as a table reference only when followed by `SELECT`/`WITH` (a derived table); a parenthesized join group was unrecognized, so `parse_table_reference` returned null, `parse_from_clause` returned null with `FROM` already consumed, and the clause was lost — a silent data-loss / wrong-plan class bug.

## Fix

In `parse_table_reference`, disambiguate a `(` in table position on its following token: `SELECT`/`WITH` stays a derived table (unchanged); an identifier or nested `(` is parsed as a **join group** by reusing the existing FROM-item / join chaining (`parse_from_clause`), then consuming the matching `)`. The inner join tree is returned as a nested `FromClause` standing in as the table reference, so the caller can attach any trailing joins on the group. A bare `(` that is neither is left unconsumed (prior behavior preserved).

Before: `trailing_token_count=23; FromClause present: NO`. After: `trailing_token_count=0; FromClause present: YES` (nested group + outer join).

## Tests

- `ParenthesizedJoinGroupInFrom` — asserts the FromClause is present, zero trailing tokens, and the nested join structure.
- `DerivedTableStillParsesAsSubquery` — control: `FROM (SELECT …) x` still a derived table.

This is the parser part of a three-repo fix; the analyzer (**DB25-Semantic-Analyzer**) and binder (**db25-logical-plan**) companion PRs make the group resolve and bind end-to-end (verified: the result matches SQLite and DuckDB exactly).