### PR TITLE
parser: classify hex/binary literals as integers

### DIFF
--- a/src/parser/parser_internal.hpp
+++ b/src/parser/parser_internal.hpp
@@ -15,8 +15,19 @@ namespace db25::parser::internal {
 
 // Select the correct literal node type for a numeric token.
 // A Number token is a float if its text carries a decimal point or an
-// exponent marker; otherwise it is an integer.
+// exponent marker; otherwise it is an integer. A hex (0x..) or binary (0b..)
+// literal is always an integer - its digits can include 'e'/'E' (a hex digit,
+// as in 0xBEEF), which must not be mistaken for a float's exponent marker.
 inline ast::NodeType number_literal_type(std::string_view text) {
+    std::string_view digits = text;
+    if (!digits.empty() && (digits.front() == '-' || digits.front() == '+')) {
+        digits.remove_prefix(1);
+    }
+    if (digits.size() >= 2 && digits[0] == '0' &&
+        (digits[1] == 'x' || digits[1] == 'X' ||
+         digits[1] == 'b' || digits[1] == 'B')) {
+        return ast::NodeType::IntegerLiteral;
+    }
     for (const char c : text) {
         if (c == '.' || c == 'e' || c == 'E') {
             return ast::NodeType::FloatLiteral;

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -177,3 +177,59 @@ TEST_F(ExprHardeningTest, NestedGetChildrenTraversalIsSafe) {
     // Cross-check: the number of children we iterated equals child_count.
     EXPECT_EQ(static_cast<uint32_t>(outer_seen), ast->child_count);
 }
+
+// ---- Numeric literal node types --------------------------------------------
+// The tokenizer now lexes hex (0x..) / binary (0b..) integers and leading-dot
+// floats (.5) as single Number tokens; the parser must classify them into the
+// right literal node. In particular a hex literal is an INTEGER even when its
+// digits include 'e'/'E' (0xBEEF), which the naive exponent check misread as a
+// float.
+
+TEST_F(ExprHardeningTest, HexLiteralIsInteger) {
+    auto* ast = parse("SELECT 0xFF FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* lit = find(ast, NodeType::IntegerLiteral);
+    ASSERT_NE(lit, nullptr);
+    EXPECT_EQ(lit->primary_text, "0xFF");
+    EXPECT_EQ(find(ast, NodeType::FloatLiteral), nullptr);
+}
+
+TEST_F(ExprHardeningTest, HexLiteralWithHexEIsInteger) {
+    // Regression: 'e'/'E' are hex digits here, not an exponent marker.
+    auto* ast = parse("SELECT 0xBEEF FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* lit = find(ast, NodeType::IntegerLiteral);
+    ASSERT_NE(lit, nullptr);
+    EXPECT_EQ(lit->primary_text, "0xBEEF");
+    EXPECT_EQ(find(ast, NodeType::FloatLiteral), nullptr);
+}
+
+TEST_F(ExprHardeningTest, BinaryLiteralIsInteger) {
+    auto* ast = parse("SELECT 0b1010 FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* lit = find(ast, NodeType::IntegerLiteral);
+    ASSERT_NE(lit, nullptr);
+    EXPECT_EQ(lit->primary_text, "0b1010");
+    EXPECT_EQ(find(ast, NodeType::FloatLiteral), nullptr);
+}
+
+TEST_F(ExprHardeningTest, LeadingDotFloatIsFloat) {
+    auto* ast = parse("SELECT .5 FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* lit = find(ast, NodeType::FloatLiteral);
+    ASSERT_NE(lit, nullptr);
+    EXPECT_EQ(lit->primary_text, ".5");
+}
+
+TEST_F(ExprHardeningTest, DecimalStaysFloatIntegerStaysInteger) {
+    // Regression guard for the ordinary decimal forms.
+    auto* d = parse("SELECT 3.14 FROM t");
+    ASSERT_NE(d, nullptr);
+    ASSERT_NE(find(d, NodeType::FloatLiteral), nullptr);
+    EXPECT_EQ(find(d, NodeType::IntegerLiteral), nullptr);
+
+    auto* i = parse("SELECT 42 FROM t");
+    ASSERT_NE(i, nullptr);
+    ASSERT_NE(find(i, NodeType::IntegerLiteral), nullptr);
+    EXPECT_EQ(find(i, NodeType::FloatLiteral), nullptr);
+}


### PR DESCRIPTION
## Context

Depends on the tokenizer change that lexes hex (`0x..`) / binary (`0b..`) integers and leading-dot floats (`.5`) as single `Number` tokens (space-rf-org/DB25-sql-tokenizer#9). This PR bumps the tokenizer submodule to that commit and handles the new tokens in the parser.

## Problem

`number_literal_type` chose `FloatLiteral` vs `IntegerLiteral` by scanning the token text for `.`, `e`, or `E`. A hex literal whose digits contain `e`/`E` — e.g. `0xBEEF`, `0x1E` — was therefore misclassified as a **float**, since the hex digit `E` looks like an exponent marker.

## Fix

`number_literal_type` now recognises a `0x`/`0X` or `0b`/`0B` prefix (after an optional leading sign) and returns `IntegerLiteral` before the exponent scan. Decimal and exponent handling is unchanged, so `.5` / `3.14` / `1e10` still classify as floats.

## Tests

Adds cases to `test_parser_expr_hardening`:

- `0xFF`, `0xBEEF` (the `E`/`e`-in-hex regression), `0b1010` → `IntegerLiteral`, no `FloatLiteral` produced;
- `.5` → `FloatLiteral`;
- regression guard that `3.14` stays float and `42` stays integer.

All 14 tests in the suite pass.


---
_Generated by [Claude Code](https://claude.ai/code)_