### PR TITLE
parser: accept delimited (double-quoted) identifiers

### DIFF
--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -233,3 +233,41 @@ TEST_F(ExprHardeningTest, DecimalStaysFloatIntegerStaysInteger) {
     ASSERT_NE(find(i, NodeType::IntegerLiteral), nullptr);
     EXPECT_EQ(find(i, NodeType::FloatLiteral), nullptr);
 }
+
+// ---- Delimited (double-quoted) identifiers ---------------------------------
+// A double-quoted lexeme is a delimited identifier, so it must reach the parser
+// as a column reference carrying the bare inner text - not a string literal.
+
+TEST_F(ExprHardeningTest, DelimitedIdentifierIsColumnRef) {
+    auto* ast = parse("SELECT \"id\" FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* col = find(ast, NodeType::ColumnRef);
+    ASSERT_NE(col, nullptr);
+    EXPECT_EQ(col->primary_text, "id");
+    // It must not have been lexed as a string literal.
+    EXPECT_EQ(find(ast, NodeType::StringLiteral), nullptr);
+}
+
+TEST_F(ExprHardeningTest, DelimitedIdentifierPreservesSpaceAndCase) {
+    auto* ast = parse("SELECT \"User Name\" FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* col = find(ast, NodeType::ColumnRef);
+    ASSERT_NE(col, nullptr);
+    EXPECT_EQ(col->primary_text, "User Name");
+}
+
+TEST_F(ExprHardeningTest, DelimitedKeywordIsIdentifierNotKeyword) {
+    // "select" in quotes is a column named select, not the SELECT keyword.
+    auto* ast = parse("SELECT \"select\" FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* col = find(ast, NodeType::ColumnRef);
+    ASSERT_NE(col, nullptr);
+    EXPECT_EQ(col->primary_text, "select");
+}
+
+TEST_F(ExprHardeningTest, SingleQuotedStaysStringLiteral) {
+    // Regression guard: single quotes remain a string literal, not an identifier.
+    auto* ast = parse("SELECT 'id' FROM t");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_NE(find(ast, NodeType::StringLiteral), nullptr);
+}


### PR DESCRIPTION
## Context

Pairs with the tokenizer change that lexes a double-quoted lexeme as an `Identifier` token carrying the bare inner text (space-rf-org/DB25-sql-tokenizer#10). Bumps the tokenizer submodule to that commit (rebased to sit on top of the merged hex/binary work).

## Change

No parser source change is required: the existing identifier path already turns an `Identifier` token into a `ColumnRef` (or `Identifier`) node with `primary_text = token value`. Because the tokenizer now delivers `"id"` as an `Identifier` whose value is `id`, delimited identifiers flow through unchanged and resolve like any other column name — including keywords (`"select"`) and names with spaces/punctuation (`"User Name"`) that are otherwise unreachable.

## Tests

Adds regression tests to `test_parser_expr_hardening`:

- `"id"` → `ColumnRef` named `id`, and **not** a `StringLiteral`;
- `"User Name"` preserves the embedded space and case;
- `"select"` is an identifier, not the `SELECT` keyword;
- `'id'` (single-quoted) still parses as a `StringLiteral` (regression guard).

Rebased onto current `main` (after #23 merged); the hex and delimited test blocks coexist — `test_parser_expr_hardening` runs **18/18**. The only unrelated failure is the pre-existing, environment-specific `ArenaEdgeTest` over-alignment case.
