### PR TITLE
parser: parse COLLATE as a postfix on value expressions

### DIFF
--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -279,6 +279,9 @@ protected:
     [[nodiscard]] ast::ASTNode* parse_table_reference();
     [[nodiscard]] ast::ASTNode* parse_case_expression();
     [[nodiscard]] ast::ASTNode* parse_cast_expression();
+    // Wrap `operand` in a CollateClause for each trailing COLLATE <name> postfix.
+    // Returns `operand` unchanged when no COLLATE follows.
+    [[nodiscard]] ast::ASTNode* parse_collate_postfix(ast::ASTNode* operand);
     [[nodiscard]] ast::ASTNode* parse_extract_expression();
     
     // ========== Pratt Parser for Expressions ==========

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -522,11 +522,19 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
     
     // Parse left side (primary expression)
     ast::ASTNode* left = parse_primary_expression();
-    
+
     if (!left) {
         return nullptr;
     }
-    
+
+    // COLLATE is a postfix that binds tighter than any binary operator, so it
+    // attaches to the primary before the precedence loop: `a = b COLLATE "C"`
+    // parses as `a = (b COLLATE "C")`.
+    left = parse_collate_postfix(left);
+    if (!left) {
+        return nullptr;
+    }
+
     // Loop to handle operators with precedence
     while (true) {
         int precedence = get_precedence();
@@ -1050,6 +1058,39 @@ ast::ASTNode* Parser::parse_cast_expression() {
     }
     
     return cast_node;
+}
+
+// ========== COLLATE postfix ==========
+
+ast::ASTNode* Parser::parse_collate_postfix(ast::ASTNode* operand) {
+    // `<value> COLLATE <collation>` annotates a value with a collation. COLLATE
+    // binds tighter than any binary operator, so it is applied as a postfix to
+    // the primary immediately after it is parsed. The collation name is stored
+    // on the CollateClause's schema_name; the annotated value is its one child.
+    while (operand != nullptr && current_token_ &&
+           current_token_->type == tokenizer::TokenType::Keyword &&
+           current_token_->keyword_id == db25::Keyword::COLLATE) {
+        advance();  // consume COLLATE
+        auto* node = arena_.allocate<ast::ASTNode>();
+        new (node) ast::ASTNode(ast::NodeType::CollateClause);
+        node->node_id = next_node_id_++;
+        node->primary_text = copy_to_arena("COLLATE");
+
+        // The collation name is an identifier (bare or delimited) or a string.
+        if (current_token_ &&
+            (current_token_->type == tokenizer::TokenType::Identifier ||
+             current_token_->type == tokenizer::TokenType::Keyword ||
+             current_token_->type == tokenizer::TokenType::String)) {
+            node->schema_name = copy_to_arena(current_token_->value);
+            advance();
+        }
+
+        operand->parent = node;
+        node->first_child = operand;
+        node->child_count = 1;
+        operand = node;
+    }
+    return operand;
 }
 
 // ========== EXTRACT Expression Parser ==========

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -271,3 +271,35 @@ TEST_F(ExprHardeningTest, SingleQuotedStaysStringLiteral) {
     ASSERT_NE(ast, nullptr);
     EXPECT_NE(find(ast, NodeType::StringLiteral), nullptr);
 }
+
+// ---- COLLATE postfix -------------------------------------------------------
+// `<value> COLLATE <name>` annotates a value with a collation. It must parse as
+// a CollateClause wrapping the value, with the collation name recorded, instead
+// of derailing the surrounding expression (which used to drop the column).
+
+TEST_F(ExprHardeningTest, CollateInProjection) {
+    auto* ast = parse("SELECT name COLLATE \"C\" FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* col = find(ast, NodeType::CollateClause);
+    ASSERT_NE(col, nullptr);
+    EXPECT_EQ(col->schema_name, "C");
+    // The annotated value is its child column reference.
+    auto* operand = col->first_child;
+    ASSERT_NE(operand, nullptr);
+    EXPECT_EQ(operand->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(operand->primary_text, "name");
+}
+
+TEST_F(ExprHardeningTest, CollateBindsTighterThanComparison) {
+    // `s COLLATE "C" = 'a'` is `(s COLLATE "C") = 'a'`: the '=' predicate's left
+    // operand is the CollateClause, and the column is not lost.
+    auto* ast = parse("SELECT * FROM t WHERE s COLLATE \"C\" = 'a'");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(pred->primary_text, "=");
+    auto* lhs = pred->first_child;
+    ASSERT_NE(lhs, nullptr);
+    EXPECT_EQ(lhs->node_type, NodeType::CollateClause);
+}


### PR DESCRIPTION
## Context

First leg of COLLATE support. `COLLATE` was a recognized keyword but **wholly unimplemented** in the expression grammar, so `SELECT s COLLATE "C"` derailed the surrounding expression — the column was lost and the statement failed to analyze. (Companion analyzer + binder PRs follow.)

## Fix

`parse_expression` now applies a `COLLATE` postfix to the primary **before** the precedence loop, so it binds tighter than any binary operator: `s COLLATE "C" = 'a'` parses as `(s COLLATE "C") = 'a'`. The annotated value becomes the single child of a `CollateClause` node whose `schema_name` holds the collation name (a bare or delimited identifier, or a string).

Placement after `parse_primary_expression()` means it composes correctly inside larger expressions — in `a + b COLLATE "C"`, COLLATE attaches to `b`.

## Tests

Adds to `test_parser_expr_hardening`:

- `name COLLATE "C"` → a `CollateClause` over the `name` column with `schema_name == "C"`;
- `s COLLATE "C" = 'a'` → the `=` predicate's left operand is the `CollateClause` (binds tighter than comparison; column not lost).

Full suite green apart from the pre-existing, environment-specific `ArenaEdgeTest` over-alignment case (unrelated to parsing).
