### PR TITLE
ast: add IntersectAll / ExceptAll to the SetOp enum

### DIFF
--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -262,7 +262,13 @@ enum class SetOp : uint8_t {
     Union,
     UnionAll,
     Intersect,
-    Except
+    Except,
+    // ALL (multiset) variants. Appended so the existing enumerators keep their
+    // values. INTERSECT ALL / EXCEPT ALL preserve duplicate rows (multiset
+    // intersection / difference); the un-suffixed forms de-duplicate. The parser
+    // already records the ALL keyword (NodeFlags::All) on these nodes.
+    IntersectAll,
+    ExceptAll
 };
 
 /**


### PR DESCRIPTION
## Why

The `SetOp` enum modelled `UNION ALL` as its own enumerator (`UnionAll`) but had **no counterpart for `INTERSECT ALL` / `EXCEPT ALL`**. A consumer therefore couldn't distinguish a multiset intersection/difference from the de-duplicating form — and downstream (in db25-logical-plan) the binder silently dropped the `ALL` keyword for these operators, collapsing them to the distinct variants.

The parser already records the `ALL` keyword as `NodeFlags::All` on `IntersectStmt` / `ExceptStmt` nodes; this change just gives the lowering somewhere to put it.

## What

Append `IntersectAll` and `ExceptAll` to `SetOp`. **Appended** (not inserted), so the existing enumerators keep their numeric values.

No behavior change on its own — this is the enabling enum change. The binder mapping and the reference evaluator that consume `SetOp` are updated in the dependent repos (db25-logical-plan and the umbrella harness) once this lands, then pinned in.