### PR TITLE
parser: consume FROM in UPDATE...FROM; parse LIKE...ESCAPE

### DIFF
--- a/src/parser/parser_dml.cpp
+++ b/src/parser/parser_dml.cpp
@@ -375,8 +375,12 @@ ast::ASTNode* Parser::parse_update_stmt() {
     last_child = set_clause;
     update_node->child_count++;
     
-    // Optional FROM clause (PostgreSQL extension)
+    // Optional FROM clause (PostgreSQL extension). parse_from_clause() begins at
+    // the first table reference (as in SELECT), so the FROM keyword must be
+    // consumed first - without this the clause failed to parse and was dropped,
+    // leaving `... FROM extra WHERE ...` columns unresolved.
     if (current_token_ && current_token_->keyword_id == db25::Keyword::FROM) {
+        advance();  // consume FROM
         auto* from_clause = parse_from_clause();
         if (from_clause) {
             from_clause->parent = update_node;

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -765,7 +765,22 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
                 pattern->parent = like_node;
                 left->next_sibling = pattern;
                 like_node->child_count = 2;
-                
+
+                // Optional ESCAPE '<char>' clause. Attach the escape-character
+                // expression as a third child; the binder lowers it into the Like
+                // node's escape slot and the evaluator treats the following
+                // pattern character literally.
+                if (current_token_ &&
+                    current_token_->type == tokenizer::TokenType::Keyword &&
+                    current_token_->keyword_id == db25::Keyword::ESCAPE) {
+                    advance();  // consume ESCAPE
+                    if (auto* escape = parse_expression(precedence + 1)) {
+                        escape->parent = like_node;
+                        pattern->next_sibling = escape;
+                        like_node->child_count = 3;
+                    }
+                }
+
                 left = like_node;
                 continue;
             }


### PR DESCRIPTION
Two parse-completeness fixes (part of the P2 DML/CTE batch):

- **`UPDATE ... FROM extra_relations` dropped its FROM clause.** The handler called `parse_from_clause()` — which begins at the first table reference, exactly as the SELECT path does — *without first consuming the `FROM` keyword*, so parsing failed and the clause was silently omitted, leaving every column from the extra relations unresolved. Consume `FROM` first, matching SELECT.
- **`LIKE ... ESCAPE '<char>'` was not parsed.** After the pattern, consume an optional `ESCAPE` keyword and attach the escape-character expression as a third child of the `LikeExpr`. The binder already lowers all children and the evaluator already honors an escape child, so **no downstream change is needed** — the feature works end-to-end once this lands and pins bump.

Verified end-to-end via the umbrella harness: `UPDATE users SET ... FROM orders o WHERE ...` now binds; `LIKE 'a!%' ESCAPE '!'` treats `%` literally (0 matches) vs `LIKE 'a%'` (matches alice).