### PR TITLE
test: guard ManySmallAllocations wall-clock assertion to NDEBUG builds

### DIFF
--- a/tests/arena/test_arena_stress.cpp
+++ b/tests/arena/test_arena_stress.cpp
@@ -166,11 +166,19 @@ TEST_F(ArenaStressTest, ManySmallAllocations) {
     auto end = high_resolution_clock::now();
     auto duration = duration_cast<milliseconds>(end - start);
     
-    std::cout << "1 million small allocations took: " 
+    std::cout << "1 million small allocations took: "
               << duration.count() << " ms\n";
-    
-    EXPECT_LT(duration.count(), 100) 
+
+    // Wall-clock budgets are only meaningful in optimized builds; -O0 debug
+    // builds and sanitizer/CI runs inflate the time well past the budget, so
+    // the assertion is enforced only under NDEBUG and skipped otherwise (same
+    // guard as AllocationSpeed / MixedSizeAllocationSpeed above).
+#ifdef NDEBUG
+    EXPECT_LT(duration.count(), 100)
         << "1 million allocations should take < 100ms";
+#else
+    GTEST_SKIP() << "Timing assertion only enforced in optimized (NDEBUG) builds";
+#endif
 }
 
 TEST_F(ArenaStressTest, ResetPerformance) {


### PR DESCRIPTION
## Summary

`ArenaStressTest.ManySmallAllocations` asserts that 1M small allocations complete in under 100ms. That absolute wall-clock budget is only meaningful in optimized builds — `-O0` debug builds and, especially, ASan/UBSan CI runs inflate the elapsed time past the boundary (observed **101ms vs the 100ms limit**), producing spurious failures unrelated to the code under test. This flake has now hit multiple unrelated PRs on the ASan+UBSan job.

## Fix

Wrap the assertion in the same `#ifdef NDEBUG` / `#else GTEST_SKIP()` guard the sibling timing tests `AllocationSpeed` and `MixedSizeAllocationSpeed` already use, so the budget is enforced only where it is meaningful (optimized builds) and skipped in debug/sanitizer builds.

- The performance signal is preserved — the timing is still printed and the assertion still runs in every `NDEBUG` (Release) build.
- No production code changes; only the test's timing gate is scoped.

## Verification

- Timing measurement and stdout are unchanged; only the `EXPECT_LT` is now conditional.
- Matches the established pattern for the two sibling timing tests in the same file.