### PR TITLE
parser: support IS [NOT] TRUE / FALSE / UNKNOWN boolean tests

### DIFF
--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -73,6 +73,7 @@ enum class NodeType : uint8_t {
     BetweenExpr,
     LikeExpr,        // LIKE pattern matching
     IsNullExpr,      // IS NULL / IS NOT NULL
+    BooleanTestExpr, // IS [NOT] TRUE / FALSE / UNKNOWN
     WindowExpr,
     
     // === Clause Nodes ===

--- a/src/ast/ast_node.cpp
+++ b/src/ast/ast_node.cpp
@@ -141,6 +141,7 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
         case NodeType::BetweenExpr: return "BetweenExpr";
         case NodeType::LikeExpr: return "LikeExpr";
         case NodeType::IsNullExpr: return "IsNullExpr";
+        case NodeType::BooleanTestExpr: return "BooleanTestExpr";
         case NodeType::WindowExpr: return "WindowExpr";
         // Clauses
         case NodeType::SelectList: return "SelectList";

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -802,24 +802,67 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
                     advance(); // consume NOT
                 }
                 
+                // IS [NOT] TRUE / FALSE / UNKNOWN -- a three-valued boolean test
+                // that collapses the operand's 3VL truth value to a plain 2VL
+                // boolean (never NULL). TRUE/FALSE tokenize as keywords; UNKNOWN
+                // is not a reserved keyword, so it arrives as a bare identifier
+                // (matched case-insensitively without a heap allocation).
+                auto is_unknown_ident = [](std::string_view v) {
+                    static constexpr char kU[] = "UNKNOWN";
+                    if (v.size() != 7) return false;
+                    for (std::size_t i = 0; i < 7; ++i) {
+                        char c = v[i];
+                        if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+                        if (c != kU[i]) return false;
+                    }
+                    return true;
+                };
+                if (current_token_ &&
+                    (current_token_->keyword_id == db25::Keyword::KW_TRUE ||
+                     current_token_->keyword_id == db25::Keyword::KW_FALSE ||
+                     is_unknown_ident(current_token_->value))) {
+                    const char* target =
+                        current_token_->keyword_id == db25::Keyword::KW_TRUE  ? "TRUE"
+                        : current_token_->keyword_id == db25::Keyword::KW_FALSE ? "FALSE"
+                        : "UNKNOWN";
+                    advance(); // consume TRUE / FALSE / UNKNOWN
+
+                    auto* bool_test_node = arena_.allocate<ast::ASTNode>();
+                    new (bool_test_node) ast::ASTNode(ast::NodeType::BooleanTestExpr);
+                    bool_test_node->node_id = next_node_id_++;
+
+                    // Store the full test, e.g. "IS TRUE" / "IS NOT UNKNOWN". The
+                    // binder reads the target off this text and the NOT off the
+                    // presence of "NOT" (matching the IsNull convention).
+                    bool_test_node->primary_text =
+                        copy_to_arena(std::string("IS ") + (is_not ? "NOT " : "") + target);
+
+                    left->parent = bool_test_node;
+                    bool_test_node->first_child = left;
+                    bool_test_node->child_count = 1;
+
+                    left = bool_test_node;
+                    continue;
+                }
+
                 // Expect NULL
                 if (!current_token_ || current_token_->type != tokenizer::TokenType::Keyword ||
                     (current_token_->value != "NULL" && current_token_->value != "null")) {
-                    return left; // Error: expected NULL
+                    return left; // Error: expected NULL / TRUE / FALSE / UNKNOWN
                 }
                 advance(); // consume NULL
-                
+
                 auto* is_null_node = arena_.allocate<ast::ASTNode>();
                 new (is_null_node) ast::ASTNode(ast::NodeType::IsNullExpr);
                 is_null_node->node_id = next_node_id_++;
-                
+
                 // Store IS NULL or IS NOT NULL
                 is_null_node->primary_text = copy_to_arena(is_not ? "IS NOT NULL" : "IS NULL");
-                
+
                 left->parent = is_null_node;
                 is_null_node->first_child = left;
                 is_null_node->child_count = 1;
-                
+
                 left = is_null_node;
                 continue;
             }

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -303,3 +303,50 @@ TEST_F(ExprHardeningTest, CollateBindsTighterThanComparison) {
     ASSERT_NE(lhs, nullptr);
     EXPECT_EQ(lhs->node_type, NodeType::CollateClause);
 }
+
+// ---- IS [NOT] TRUE / FALSE / UNKNOWN --------------------------------------
+
+TEST_F(ExprHardeningTest, IsTrueBuildsBooleanTest) {
+    // `flag IS TRUE` is a BooleanTestExpr over the column, not an IsNullExpr and
+    // not a dropped predicate.
+    auto* ast = parse("SELECT * FROM t WHERE flag IS TRUE");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BooleanTestExpr);
+    EXPECT_EQ(pred->primary_text, "IS TRUE");
+    auto* operand = pred->first_child;
+    ASSERT_NE(operand, nullptr);
+    EXPECT_EQ(operand->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(operand->primary_text, "flag");
+}
+
+TEST_F(ExprHardeningTest, IsNotFalseBuildsNegatedBooleanTest) {
+    auto* ast = parse("SELECT * FROM t WHERE flag IS NOT FALSE");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BooleanTestExpr);
+    EXPECT_EQ(pred->primary_text, "IS NOT FALSE");
+}
+
+TEST_F(ExprHardeningTest, IsUnknownBuildsBooleanTest) {
+    // UNKNOWN is not a reserved keyword; it arrives as an identifier and must
+    // still be recognized (case-insensitively) as the boolean-test target.
+    auto* ast = parse("SELECT * FROM t WHERE (a > b) is unknown");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BooleanTestExpr);
+    EXPECT_EQ(pred->primary_text, "IS UNKNOWN");
+}
+
+TEST_F(ExprHardeningTest, IsNullStillParsesAfterBooleanTest) {
+    // Regression guard: the IS handler must still route NULL to IsNullExpr.
+    auto* ast = parse("SELECT * FROM t WHERE x IS NOT NULL");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::IsNullExpr);
+    EXPECT_EQ(pred->primary_text, "IS NOT NULL");
+}


### PR DESCRIPTION
## Summary

The `IS` handler accepted only `NULL` after `IS` / `IS NOT`, and errored — silently returning the left operand — on `TRUE` / `FALSE` / `UNKNOWN`. So the three-valued boolean tests `x IS TRUE`, `x IS NOT FALSE`, `x IS UNKNOWN`, etc. were unparseable.

## What

Extend the handler to build a new **`BooleanTestExpr`** node for `IS [NOT] TRUE/FALSE/UNKNOWN`:

- `TRUE` / `FALSE` tokenize as keywords (`KW_TRUE` / `KW_FALSE`); `UNKNOWN` is **not** a reserved keyword, so it arrives as an identifier and is matched case-insensitively (no heap allocation).
- The full test text (e.g. `"IS NOT TRUE"`) is stored in `primary_text`; downstream, the binder reads the target from it and the negation from the presence of `NOT` — the same convention `IsNullExpr` already uses.
- Adds `NodeType::BooleanTestExpr` and its `node_type_to_string` case.

This is a parser-only change; binder lowering + evaluator semantics (3VL → 2VL) follow in the db25-logical-plan and umbrella cascade.

## Tests

Four regression tests in `test_parser_expr_hardening.cpp`:
- `flag IS TRUE` → `BooleanTestExpr("IS TRUE")` over the column,
- `flag IS NOT FALSE` → negated boolean test,
- lowercase `(a > b) is unknown` → recognized via the identifier path,
- `x IS NOT NULL` → **still** routes to `IsNullExpr` (regression guard).

Full suite: **37/37 test targets pass**.