### PR TITLE
parser: support aggregate FILTER (WHERE ...) clause

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1737,7 +1737,49 @@ ast::ASTNode* Parser::parse_function_call() {
         }
     }
     pop_context();
-    
+
+    // Optional aggregate FILTER (WHERE predicate) clause, e.g.
+    //   COUNT(*) FILTER (WHERE amount > 0)
+    // Sits between the argument list and any OVER clause. The predicate is
+    // wrapped in a WhereClause node attached as a child of the call, so the
+    // binder can tell it apart from the aggregate's arguments.
+    if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+        current_token_->keyword_id == db25::Keyword::FILTER) {
+        advance();  // consume FILTER
+        if (current_token_ && current_token_->value == "(") {
+            parenthesis_depth_++;
+            advance();  // consume '('
+            if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                current_token_->keyword_id == db25::Keyword::WHERE) {
+                advance();  // consume WHERE
+                ast::ASTNode* pred = parse_expression(0);
+                if (pred) {
+                    auto* where_node = arena_.allocate<ast::ASTNode>();
+                    new (where_node) ast::ASTNode(ast::NodeType::WhereClause);
+                    where_node->node_id = next_node_id_++;
+                    where_node->primary_text = copy_to_arena("FILTER");
+                    pred->parent = where_node;
+                    where_node->first_child = pred;
+                    where_node->child_count = 1;
+                    // Attach the FILTER clause as the call's last child.
+                    where_node->parent = func_call;
+                    if (func_call->first_child) {
+                        ast::ASTNode* last = func_call->first_child;
+                        while (last->next_sibling) last = last->next_sibling;
+                        last->next_sibling = where_node;
+                    } else {
+                        func_call->first_child = where_node;
+                    }
+                    func_call->child_count++;
+                }
+            }
+            if (current_token_ && current_token_->value == ")") {
+                if (parenthesis_depth_ > 0) parenthesis_depth_--;
+                advance();  // consume ')'
+            }
+        }
+    }
+
     // Check for OVER clause (window function)
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         (current_token_->keyword_id == db25::Keyword::OVER)) {

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -385,3 +385,36 @@ TEST_F(ExprHardeningTest, PlainLikeStillParses) {
     EXPECT_EQ(pred->node_type, NodeType::LikeExpr);
     EXPECT_EQ(pred->primary_text, "LIKE");
 }
+
+// ---- Aggregate FILTER (WHERE ...) -----------------------------------------
+
+TEST_F(ExprHardeningTest, AggregateFilterAttachesWhereClause) {
+    // COUNT(*) FILTER (WHERE age > 20): the FILTER predicate attaches as a
+    // WhereClause child of the call, distinct from the (star) argument.
+    auto* ast = parse("SELECT COUNT(*) FILTER (WHERE age > 20) FROM users");
+    ASSERT_NE(ast, nullptr);
+    auto* call = find(ast, NodeType::FunctionCall);
+    ASSERT_NE(call, nullptr);
+    EXPECT_EQ(call->primary_text, "COUNT");
+    // Find the WhereClause (FILTER) child.
+    ASTNode* filter = nullptr;
+    for (auto* c = call->first_child; c; c = c->next_sibling)
+        if (c->node_type == NodeType::WhereClause) { filter = c; break; }
+    ASSERT_NE(filter, nullptr) << "FILTER should attach a WhereClause child";
+    EXPECT_EQ(filter->primary_text, "FILTER");
+    // Its child is the predicate.
+    auto* pred = filter->first_child;
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(pred->primary_text, ">");
+}
+
+TEST_F(ExprHardeningTest, AggregateWithoutFilterHasNoWhereClause) {
+    // Regression guard: a plain aggregate has no WhereClause child.
+    auto* ast = parse("SELECT COUNT(*) FROM users");
+    ASSERT_NE(ast, nullptr);
+    auto* call = find(ast, NodeType::FunctionCall);
+    ASSERT_NE(call, nullptr);
+    for (auto* c = call->first_child; c; c = c->next_sibling)
+        EXPECT_NE(c->node_type, NodeType::WhereClause);
+}


### PR DESCRIPTION
## Summary

`FILTER` tokenizes as its own keyword but was never parsed, so `agg(...) FILTER (WHERE pred)` failed.

## What

Parse an optional `FILTER (WHERE p)` clause in `parse_function_call`, positioned between the argument list and any `OVER` clause (the SQL grammar order). The predicate is wrapped in a `WhereClause` node (`primary_text` `"FILTER"`) attached as the call's last child, so the binder and analyzer can tell it apart from the aggregate's value arguments — the same shape already used for the `OVER` `WindowSpec` child.

This is a parser-only change; the binder attaching the predicate to the aggregate and the evaluator restricting rows follow in the db25-logical-plan and umbrella cascade.

## Tests

Two regression tests in `test_parser_expr_hardening.cpp`:
- `COUNT(*) FILTER (WHERE age > 20)` attaches a `WhereClause` child whose child is the `>` predicate,
- a plain `COUNT(*)` has **no** `WhereClause` child (regression guard).

Full suite: **37/37 test targets pass**.