### PR TITLE
parser: unify row constructors on RowConstructor (ROW(...) and bare tuples)

### DIFF
--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -232,11 +232,13 @@ ast::ASTNode* Parser::parse_primary_expression() {
             auto* first = parse_expression(0);
 
             // Row constructor: a comma after the first expression means this is
-            // a parenthesised expression list, not a simple grouping.
+            // a parenthesised expression list "(a, b, ...)", not a simple
+            // grouping. Same RowConstructor node as the explicit ROW(...) form.
             if (current_token_ && current_token_->value == ",") {
                 auto* row_node = arena_.allocate<ast::ASTNode>();
-                new (row_node) ast::ASTNode(ast::NodeType::RowExpr);
+                new (row_node) ast::ASTNode(ast::NodeType::RowConstructor);
                 row_node->node_id = next_node_id_++;
+                row_node->primary_text = copy_to_arena("ROW");
                 if (first) {
                     first->parent = row_node;
                     row_node->first_child = first;
@@ -355,6 +357,38 @@ ast::ASTNode* Parser::parse_primary_expression() {
                 advance(); // consume ']'
             }
             return array_node;
+        }
+
+        // ROW(a, b, ...) explicit row constructor. Handled before the function-
+        // call path so ROW is not parsed as a function named "ROW". Unlike the
+        // bare (a, b) form below, ROW(x) with a single element is still a row.
+        if (current_token_->type == tokenizer::TokenType::Keyword &&
+            current_token_->keyword_id == db25::Keyword::ROW &&
+            peek_token_ && peek_token_->value == "(") {
+            advance();  // consume ROW
+            parenthesis_depth_++;
+            advance();  // consume '('
+            auto* row_node = arena_.allocate<ast::ASTNode>();
+            new (row_node) ast::ASTNode(ast::NodeType::RowConstructor);
+            row_node->node_id = next_node_id_++;
+            row_node->primary_text = copy_to_arena("ROW");
+            ast::ASTNode* last = nullptr;
+            while (current_token_ && current_token_->value != ")") {
+                auto* el = parse_expression(0);
+                if (!el) break;
+                el->parent = row_node;
+                if (!row_node->first_child) row_node->first_child = el;
+                else last->next_sibling = el;
+                last = el;
+                row_node->child_count++;
+                if (current_token_ && current_token_->value == ",") advance();
+                else break;
+            }
+            if (current_token_ && current_token_->value == ")") {
+                if (parenthesis_depth_ > 0) parenthesis_depth_--;
+                advance();  // consume ')'
+            }
+            return row_node;
         }
 
         // Look ahead using peek_token_

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -418,3 +418,51 @@ TEST_F(ExprHardeningTest, AggregateWithoutFilterHasNoWhereClause) {
     for (auto* c = call->first_child; c; c = c->next_sibling)
         EXPECT_NE(c->node_type, NodeType::WhereClause);
 }
+
+// ---- Row constructors ------------------------------------------------------
+
+TEST_F(ExprHardeningTest, BareTupleBuildsRowConstructor) {
+    // (a, b) with a top-level comma is a RowConstructor with two children.
+    auto* ast = parse("SELECT * FROM t WHERE (a, b) = (1, 2)");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(pred->primary_text, "=");
+    auto* lhs = pred->first_child;
+    ASSERT_NE(lhs, nullptr);
+    EXPECT_EQ(lhs->node_type, NodeType::RowConstructor);
+    EXPECT_EQ(lhs->child_count, 2);
+    auto* rhs = lhs->next_sibling;
+    ASSERT_NE(rhs, nullptr);
+    EXPECT_EQ(rhs->node_type, NodeType::RowConstructor);
+    EXPECT_EQ(rhs->child_count, 2);
+}
+
+TEST_F(ExprHardeningTest, ExplicitRowKeywordBuildsRowConstructor) {
+    // ROW(a, b, c) is a RowConstructor, not a function call named ROW.
+    auto* ast = parse("SELECT * FROM t WHERE ROW(a, b, c) = ROW(1, 2, 3)");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    auto* lhs = pred->first_child;
+    ASSERT_NE(lhs, nullptr);
+    EXPECT_EQ(lhs->node_type, NodeType::RowConstructor);
+    EXPECT_EQ(lhs->child_count, 3);
+    EXPECT_EQ(find(ast, NodeType::FunctionCall), nullptr) << "ROW must not be a FunctionCall";
+}
+
+TEST_F(ExprHardeningTest, SingleParenIsGroupingNotRow) {
+    // CRITICAL regression guard: (a + b) with NO comma is ordinary grouping,
+    // NOT a one-element row constructor.
+    auto* ast = parse("SELECT * FROM t WHERE (a + b) = 3");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    auto* lhs = pred->first_child;
+    ASSERT_NE(lhs, nullptr);
+    EXPECT_EQ(lhs->node_type, NodeType::BinaryExpr);  // the (a + b) group
+    EXPECT_EQ(lhs->primary_text, "+");
+    EXPECT_EQ(find(ast, NodeType::RowConstructor), nullptr) << "no comma -> no row";
+}


### PR DESCRIPTION
## Summary

Two gaps in row-value parsing:

- `ROW(a, b, c)` parsed as a **function call named "ROW"** rather than a row constructor.
- the bare `(a, b, ...)` tuple form built a `RowExpr` node (the "row in VALUES" type) that **nothing downstream consumes**.

## What

- Handle `ROW(...)` explicitly before the function-call path (mirroring the `ARRAY[...]` handling) and emit a `RowConstructor`.
- Switch the bare-tuple branch to the same `RowConstructor` node, so both surface syntaxes produce one consistent node the binder can lower.
- A single `(expr)` with **no** top-level comma stays plain grouping — ordinary parenthesization is unchanged.

`RowExpr` was only ever constructed in this one spot (`VALUES` uses its own path) and consumed nowhere, so retargeting it is safe.

This is a parser-only change; binder lowering + the row-comparison evaluator semantics follow in the db25-logical-plan and umbrella cascade.

## Tests

- `(a, b) = (1, 2)` → both sides `RowConstructor` (2 children each),
- `ROW(a, b, c) = ROW(1, 2, 3)` → `RowConstructor` (3 children), and **not** a `FunctionCall`,
- **critical regression guard:** `(a + b) = 3` stays ordinary grouping with **no** `RowConstructor`.

Full suite: **37/37 test targets pass** (no regression on the hot parenthesized-expression path).