### PR TITLE
parser: capture stubbed DDL column lists (INDEX, table-level FK / UNIQUE)

### DIFF
--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -57,6 +57,7 @@ enum class NodeType : uint8_t {
     ForeignKeyConstraint,
     PrimaryKeyConstraint,
     UniqueConstraint,
+    ReferencesClause,  // REFERENCES <table> (<cols>) inside a table-level FK
     IndexColumn,
     AlterTableAction,
     

--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -243,6 +243,9 @@ protected:
     [[nodiscard]] ast::ASTNode* parse_column_definition();
     [[nodiscard]] ast::ASTNode* parse_column_constraint();
     [[nodiscard]] ast::ASTNode* parse_table_constraint();
+    // Parse a parenthesized identifier list "( a, b, ... )" and attach each name
+    // as an Identifier child of `parent`. Returns the number of names consumed.
+    int parse_paren_identifier_list(ast::ASTNode* parent);
     
     // Transaction control statements
     [[nodiscard]] ast::ASTNode* parse_transaction_stmt();

--- a/src/ast/ast_node.cpp
+++ b/src/ast/ast_node.cpp
@@ -205,6 +205,7 @@ void ASTNode::remove_child(ASTNode* const child) noexcept {
         case NodeType::IntervalLiteral: return "IntervalLiteral";
         case NodeType::ArrayConstructor: return "ArrayConstructor";
         case NodeType::RowConstructor: return "RowConstructor";
+        case NodeType::ReferencesClause: return "ReferencesClause";
         case NodeType::JsonLiteral: return "JsonLiteral";
         case NodeType::CollateClause: return "CollateClause";
         case NodeType::SearchClause: return "SearchClause";

--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -177,17 +177,12 @@ ast::ASTNode* Parser::parse_create_index_impl() {
         }
     }
     
-    // Parse column list (simplified)
+    // Parse the indexed column list, attaching each column as an Identifier
+    // child of the CREATE INDEX node.
     if (current_token_ && current_token_->value == "(") {
-        int paren_depth = 1;
-        advance();
-        while (current_token_ && paren_depth > 0) {
-            if (current_token_->value == "(") paren_depth++;
-            else if (current_token_->value == ")") paren_depth--;
-            advance();
-        }
+        parse_paren_identifier_list(create_node);
     }
-    
+
     return create_node;
 }
 
@@ -582,6 +577,49 @@ ast::ASTNode* Parser::parse_column_constraint() {
 }
 
 // Parse column definition
+int Parser::parse_paren_identifier_list(ast::ASTNode* parent) {
+    int count = 0;
+    if (!current_token_ || current_token_->value != "(") return 0;
+    advance();  // consume '('
+    parenthesis_depth_++;
+    ast::ASTNode* last = parent->first_child;
+    while (last != nullptr && last->next_sibling != nullptr) last = last->next_sibling;
+    // A column name may be an identifier or a non-reserved keyword used as a
+    // name (e.g. FIRST, LAST), matching how the rest of the parser accepts
+    // keywords in name position.
+    while (current_token_ &&
+           (current_token_->type == tokenizer::TokenType::Identifier ||
+            current_token_->type == tokenizer::TokenType::Keyword)) {
+        auto* col = arena_.allocate<ast::ASTNode>();
+        new (col) ast::ASTNode(ast::NodeType::Identifier);
+        col->node_id = next_node_id_++;
+        col->primary_text = copy_to_arena(current_token_->value);
+        col->parent = parent;
+        if (parent->first_child == nullptr) {
+            parent->first_child = col;
+        } else if (last != nullptr) {
+            last->next_sibling = col;
+        }
+        last = col;
+        parent->child_count++;
+        ++count;
+        advance();
+        if (current_token_ && current_token_->value == ",") {
+            advance();
+        } else {
+            break;
+        }
+    }
+    // Consume through the closing ')', tolerating anything unexpected so a
+    // malformed list cannot desynchronise the enclosing parser.
+    while (current_token_ && current_token_->value != ")") advance();
+    if (current_token_ && current_token_->value == ")") {
+        advance();  // consume ')'
+        if (parenthesis_depth_ > 0) parenthesis_depth_--;
+    }
+    return count;
+}
+
 ast::ASTNode* Parser::parse_column_definition() {
     if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
     
@@ -695,18 +733,38 @@ ast::ASTNode* Parser::parse_table_constraint() {
             constraint = arena_.allocate<ast::ASTNode>();
             new (constraint) ast::ASTNode(ast::NodeType::ForeignKeyConstraint);
             constraint->node_id = next_node_id_++;
-            
-            // Parse local columns
+
+            // Local columns: FOREIGN KEY (a, b, ...) - attached as Identifier
+            // children of the constraint.
             if (current_token_ && current_token_->value == "(") {
-                // Parse column list (similar to above)
-                // ... (implementation similar to PRIMARY KEY)
+                parse_paren_identifier_list(constraint);
             }
-            
-            // Parse REFERENCES
+
+            // REFERENCES <table> (<cols>): the referenced table + columns live
+            // under a ReferencesClause child so they are unambiguously distinct
+            // from the local columns above.
             if (current_token_ && current_token_->keyword_id == db25::Keyword::REFERENCES) {
                 advance();
-                // Parse referenced table and columns
-                // ... (implementation as in column constraint)
+                auto* ref = arena_.allocate<ast::ASTNode>();
+                new (ref) ast::ASTNode(ast::NodeType::ReferencesClause);
+                ref->node_id = next_node_id_++;
+                if (current_token_ && current_token_->type == tokenizer::TokenType::Identifier) {
+                    ref->primary_text = copy_to_arena(current_token_->value);  // ref table
+                    advance();
+                }
+                if (current_token_ && current_token_->value == "(") {
+                    parse_paren_identifier_list(ref);  // referenced columns
+                }
+                ref->parent = constraint;
+                // Append the ReferencesClause after any local-column children.
+                if (constraint->first_child == nullptr) {
+                    constraint->first_child = ref;
+                } else {
+                    ast::ASTNode* last = constraint->first_child;
+                    while (last->next_sibling != nullptr) last = last->next_sibling;
+                    last->next_sibling = ref;
+                }
+                constraint->child_count++;
             }
         }
     } else if (current_token_ && current_token_->keyword_id == db25::Keyword::UNIQUE) {
@@ -714,11 +772,10 @@ ast::ASTNode* Parser::parse_table_constraint() {
         constraint = arena_.allocate<ast::ASTNode>();
         new (constraint) ast::ASTNode(ast::NodeType::UniqueConstraint);
         constraint->node_id = next_node_id_++;
-        
-        // Parse column list
+
+        // UNIQUE (a, b, ...): columns attached as Identifier children.
         if (current_token_ && current_token_->value == "(") {
-            // Parse column list (similar to PRIMARY KEY)
-            // ... (implementation similar to PRIMARY KEY)
+            parse_paren_identifier_list(constraint);
         }
     } else if (current_token_ && current_token_->keyword_id == db25::Keyword::CHECK) {
         advance();

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -452,6 +452,48 @@ TEST_F(ExprHardeningTest, ExplicitRowKeywordBuildsRowConstructor) {
     EXPECT_EQ(find(ast, NodeType::FunctionCall), nullptr) << "ROW must not be a FunctionCall";
 }
 
+// ---- DDL column lists (previously stubbed) --------------------------------
+
+TEST_F(ExprHardeningTest, CreateIndexCapturesColumns) {
+    auto* ast = parse("CREATE INDEX idx_uc ON users (last, first)");
+    ASSERT_NE(ast, nullptr);
+    auto* idx = find(ast, NodeType::CreateIndexStmt);
+    ASSERT_NE(idx, nullptr);
+    EXPECT_EQ(idx->primary_text, "idx_uc");
+    EXPECT_EQ(idx->schema_name, "users");
+    EXPECT_EQ(count(idx, NodeType::Identifier), 2);  // last, first
+    ASSERT_NE(idx->first_child, nullptr);
+    EXPECT_EQ(idx->first_child->node_type, NodeType::Identifier);
+    EXPECT_EQ(idx->first_child->primary_text, "last");
+}
+
+TEST_F(ExprHardeningTest, TableLevelForeignKeyCapturesColumnsAndReferences) {
+    auto* ast = parse(
+        "CREATE TABLE orders (uid INTEGER, "
+        "FOREIGN KEY (uid) REFERENCES users (id))");
+    ASSERT_NE(ast, nullptr);
+    auto* fk = find(ast, NodeType::ForeignKeyConstraint);
+    ASSERT_NE(fk, nullptr);
+    // First child is the local column; then a ReferencesClause.
+    ASSERT_NE(fk->first_child, nullptr);
+    EXPECT_EQ(fk->first_child->node_type, NodeType::Identifier);
+    EXPECT_EQ(fk->first_child->primary_text, "uid");
+    auto* ref = find(fk, NodeType::ReferencesClause);
+    ASSERT_NE(ref, nullptr);
+    EXPECT_EQ(ref->primary_text, "users");                     // referenced table
+    ASSERT_NE(ref->first_child, nullptr);
+    EXPECT_EQ(ref->first_child->node_type, NodeType::Identifier);
+    EXPECT_EQ(ref->first_child->primary_text, "id");           // referenced column
+}
+
+TEST_F(ExprHardeningTest, TableLevelUniqueCapturesColumns) {
+    auto* ast = parse("CREATE TABLE t (a INTEGER, b INTEGER, UNIQUE (a, b))");
+    ASSERT_NE(ast, nullptr);
+    auto* uq = find(ast, NodeType::UniqueConstraint);
+    ASSERT_NE(uq, nullptr);
+    EXPECT_EQ(count(uq, NodeType::Identifier), 2);
+}
+
 TEST_F(ExprHardeningTest, SingleParenIsGroupingNotRow) {
     // CRITICAL regression guard: (a + b) with NO comma is ordinary grouping,
     // NOT a one-element row constructor.


### PR DESCRIPTION
Unblocks the exhaustive DDL work: three DDL column lists were parsed as "skip to the matching paren" stubs, so their columns never reached the AST.

## What was stubbed

- `CREATE INDEX … (cols)` — indexed columns discarded.
- `FOREIGN KEY (cols) REFERENCES t (cols)` as a **table** constraint — both column lists and the referenced table discarded (only an empty node was created).
- `UNIQUE (cols)` as a **table** constraint — columns discarded.

(Column-level FK, `CHECK`, and `DEFAULT` were already fully parsed and are untouched.)

## What

- Adds a shared **`parse_paren_identifier_list`** helper: consumes `( a, b, … )` and attaches each name as an `Identifier` child of a given parent. It tolerates a non-reserved keyword used as a column name (`FIRST`, `LAST`) and **always consumes through the closing paren**, so a malformed list cannot desynchronise the enclosing parser.
- Wires it into all three sites.
- Table-level `FOREIGN KEY` now carries its **local** columns as `Identifier` children plus a new **`ReferencesClause`** child holding the referenced table (`primary_text`) and referenced columns (`Identifier` children) — an unambiguous separation of local vs referenced columns (the column-level form didn't need this, since its local column was implicit). Adds the `ReferencesClause` node type.

## Tests

- `CREATE INDEX` captures its columns;
- table-level FK captures local columns **and** a `ReferencesClause` with the referenced table + columns;
- table-level `UNIQUE` captures its columns.

Full suite **37/37** — column-level FK, `CHECK`, `DEFAULT`, and all expression parsing unchanged.

## Cascade

Unblocks the analyzer `CREATE/DROP INDEX` and table-level FK features.