### PR TITLE
parser: capture ALTER COLUMN SET DEFAULT expression source text

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -1065,13 +1065,28 @@ ast::ASTNode* Parser::parse_alter_table_full() {
                 advance();
                 if (current_token_ && current_token_->keyword_id == db25::Keyword::KW_DEFAULT) {
                     advance();
-                    // Parse default expression
+                    // Wrap the new default in a DefaultClause carrying the verbatim
+                    // expression source text, matching a column-definition DEFAULT
+                    // so downstream consumers read the default the same way in both
+                    // places (see parse_column_constraint).
+                    auto* def = arena_.allocate<ast::ASTNode>();
+                    new (def) ast::ASTNode(ast::NodeType::DefaultClause);
+                    def->node_id = next_node_id_++;
+                    def->parent = action;
+                    const char* expr_begin =
+                        current_token_ ? current_token_->value.data() : nullptr;
                     auto* expr = parse_expression(0);
                     if (expr) {
-                        expr->parent = action;
-                        col->next_sibling = expr;
-                        action->child_count++;
+                        expr->parent = def;
+                        def->first_child = expr;
+                        def->child_count = 1;
                     }
+                    const std::string_view text = expr_source_span(tokenizer_, expr_begin);
+                    if (!text.empty()) {
+                        def->primary_text = copy_to_arena(text);
+                    }
+                    col->next_sibling = def;
+                    action->child_count++;
                 }
             } else if (current_token_ && current_token_->keyword_id == db25::Keyword::DROP) {
                 advance();

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -484,6 +484,22 @@ TEST_F(ExprHardeningTest, DefaultClauseCapturesExprText) {
     EXPECT_EQ(d2->primary_text, "now()");
 }
 
+TEST_F(ExprHardeningTest, AlterColumnSetDefaultCapturesExprText) {
+    // ALTER COLUMN SET DEFAULT wraps the new default in a DefaultClause carrying
+    // the verbatim source text, exactly like a column-definition DEFAULT.
+    auto* ast = parse("ALTER TABLE t ALTER COLUMN a SET DEFAULT 42");
+    ASSERT_NE(ast, nullptr);
+    auto* d = find(ast, NodeType::DefaultClause);
+    ASSERT_NE(d, nullptr);
+    EXPECT_EQ(d->primary_text, "42");
+
+    auto* fn = parse("ALTER TABLE t ALTER COLUMN ts SET DEFAULT now()");
+    ASSERT_NE(fn, nullptr);
+    auto* d2 = find(fn, NodeType::DefaultClause);
+    ASSERT_NE(d2, nullptr);
+    EXPECT_EQ(d2->primary_text, "now()");
+}
+
 // ---- DDL column lists (previously stubbed) --------------------------------
 
 TEST_F(ExprHardeningTest, CreateIndexCapturesColumns) {


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ALTER COLUMN c SET DEFAULT <expr>` attached the parsed expression directly to the action node with **no source text** — unlike a column definition's `DEFAULT`, whose verbatim text the analyzer relies on to persist the default faithfully.

This wraps the new default in a `DefaultClause` node carrying the verbatim expression text (via the existing `expr_source_span` helper), so a `SET DEFAULT` reads the same way downstream as a column-definition `DEFAULT` — a single convention for both.

## Testing

Adds `AlterColumnSetDefaultCapturesExprText`, asserting the captured text for a literal (`42`) and a function (`now()`) default. Full 37-test suite green, clean under ASan + UBSan.

## Why

Enables the analyzer to implement `ALTER TABLE ALTER COLUMN SET / DROP DEFAULT` (persisting the default into the catalog) without a lossy AST-to-text reconstruction — mirroring how CHECK / column-DEFAULT text is already captured.