### PR TITLE
parser: recognize ALTER COLUMN SET / DROP NOT NULL

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -1087,12 +1087,24 @@ ast::ASTNode* Parser::parse_alter_table_full() {
                     }
                     col->next_sibling = def;
                     action->child_count++;
+                } else if (current_token_ && current_token_->keyword_id == db25::Keyword::NOT) {
+                    advance();  // consume NOT
+                    if (current_token_ && current_token_->keyword_id == db25::Keyword::KW_NULL) {
+                        advance();  // consume NULL
+                        action->semantic_flags |= 0x08;  // SET NOT NULL flag
+                    }
                 }
             } else if (current_token_ && current_token_->keyword_id == db25::Keyword::DROP) {
                 advance();
                 if (current_token_ && current_token_->keyword_id == db25::Keyword::KW_DEFAULT) {
                     advance();
                     action->semantic_flags |= 0x04;  // DROP DEFAULT flag
+                } else if (current_token_ && current_token_->keyword_id == db25::Keyword::NOT) {
+                    advance();  // consume NOT
+                    if (current_token_ && current_token_->keyword_id == db25::Keyword::KW_NULL) {
+                        advance();  // consume NULL
+                        action->semantic_flags |= 0x10;  // DROP NOT NULL flag
+                    }
                 }
             } else if (current_token_ && current_token_->keyword_id == db25::Keyword::TYPE) {
                 advance();

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -500,6 +500,23 @@ TEST_F(ExprHardeningTest, AlterColumnSetDefaultCapturesExprText) {
     EXPECT_EQ(d2->primary_text, "now()");
 }
 
+TEST_F(ExprHardeningTest, AlterColumnSetDropNotNull) {
+    // SET NOT NULL / DROP NOT NULL are recorded as flags on the action node.
+    auto* a1 = parse("ALTER TABLE t ALTER COLUMN c SET NOT NULL");
+    ASSERT_NE(a1, nullptr);
+    auto* act1 = find(a1, NodeType::AlterTableAction);
+    ASSERT_NE(act1, nullptr);
+    EXPECT_TRUE(act1->semantic_flags & 0x08) << "SET NOT NULL flag";
+    EXPECT_FALSE(act1->semantic_flags & 0x10);
+
+    auto* a2 = parse("ALTER TABLE t ALTER COLUMN c DROP NOT NULL");
+    ASSERT_NE(a2, nullptr);
+    auto* act2 = find(a2, NodeType::AlterTableAction);
+    ASSERT_NE(act2, nullptr);
+    EXPECT_TRUE(act2->semantic_flags & 0x10) << "DROP NOT NULL flag";
+    EXPECT_FALSE(act2->semantic_flags & 0x08);
+}
+
 // ---- DDL column lists (previously stubbed) --------------------------------
 
 TEST_F(ExprHardeningTest, CreateIndexCapturesColumns) {


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ALTER COLUMN c` only parsed `SET DEFAULT` / `DROP DEFAULT` / `TYPE` — `SET NOT NULL` and `DROP NOT NULL` were silently consumed as an empty action.

This recognizes them and records the intent as flags on the `AlterTableAction` node:
- `0x08` = SET NOT NULL
- `0x10` = DROP NOT NULL

alongside the existing `0x04` = DROP DEFAULT.

## Testing

Adds `AlterColumnSetDropNotNull`, asserting each flag is set (and the other is not). Full 37-test suite green, clean under ASan + UBSan.

## Why

Enables the analyzer to implement `ALTER TABLE ALTER COLUMN SET / DROP NOT NULL` (toggling the column's nullability in the catalog).