### PR TITLE
parser: parse ALTER TABLE ADD table-level constraint

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -1001,17 +1001,35 @@ ast::ASTNode* Parser::parse_alter_table_full() {
     if (current_token_ && current_token_->keyword_id == db25::Keyword::ADD) {
         advance();
         action->primary_text = copy_to_arena("ADD");
-        
-        if (current_token_ && current_token_->keyword_id == db25::Keyword::COLUMN) {
-            advance(); // optional COLUMN keyword
-        }
-        
-        // Parse column definition
-        auto* column = parse_column_definition();
-        if (column) {
-            column->parent = action;
-            action->first_child = column;
-            action->child_count = 1;
+
+        // ADD [CONSTRAINT ...] PRIMARY KEY / UNIQUE / CHECK / FOREIGN KEY adds a
+        // table-level constraint; anything else is ADD [COLUMN] <definition>. The
+        // leading keyword disambiguates (a column name is never one of these).
+        const bool is_table_constraint =
+            current_token_ &&
+            (current_token_->keyword_id == db25::Keyword::CONSTRAINT ||
+             current_token_->keyword_id == db25::Keyword::PRIMARY ||
+             current_token_->keyword_id == db25::Keyword::UNIQUE ||
+             current_token_->keyword_id == db25::Keyword::CHECK ||
+             current_token_->keyword_id == db25::Keyword::FOREIGN);
+
+        if (is_table_constraint) {
+            auto* constraint = parse_table_constraint();
+            if (constraint) {
+                constraint->parent = action;
+                action->first_child = constraint;
+                action->child_count = 1;
+            }
+        } else {
+            if (current_token_ && current_token_->keyword_id == db25::Keyword::COLUMN) {
+                advance(); // optional COLUMN keyword
+            }
+            auto* column = parse_column_definition();
+            if (column) {
+                column->parent = action;
+                action->first_child = column;
+                action->child_count = 1;
+            }
         }
     } else if (current_token_ && current_token_->keyword_id == db25::Keyword::DROP) {
         advance();

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -500,6 +500,34 @@ TEST_F(ExprHardeningTest, AlterColumnSetDefaultCapturesExprText) {
     EXPECT_EQ(d2->primary_text, "now()");
 }
 
+TEST_F(ExprHardeningTest, AlterTableAddConstraint) {
+    // ADD [table-constraint] parses to the matching constraint node under the
+    // ALTER action, not a column definition.
+    auto* pk = parse("ALTER TABLE t ADD PRIMARY KEY (a, b)");
+    ASSERT_NE(pk, nullptr);
+    ASSERT_NE(find(pk, NodeType::PrimaryKeyConstraint), nullptr);
+    EXPECT_EQ(find(pk, NodeType::ColumnDefinition), nullptr);
+
+    auto* uq = parse("ALTER TABLE t ADD UNIQUE (email)");
+    ASSERT_NE(uq, nullptr);
+    EXPECT_NE(find(uq, NodeType::UniqueConstraint), nullptr);
+
+    auto* ck = parse("ALTER TABLE t ADD CHECK (age >= 0)");
+    ASSERT_NE(ck, nullptr);
+    auto* chk = find(ck, NodeType::CheckConstraint);
+    ASSERT_NE(chk, nullptr);
+    EXPECT_EQ(chk->primary_text, "age >= 0");
+
+    auto* fk = parse("ALTER TABLE t ADD FOREIGN KEY (pid) REFERENCES parent (id)");
+    ASSERT_NE(fk, nullptr);
+    EXPECT_NE(find(fk, NodeType::ForeignKeyConstraint), nullptr);
+
+    // ADD COLUMN still works (no constraint keyword).
+    auto* col = parse("ALTER TABLE t ADD COLUMN c INTEGER");
+    ASSERT_NE(col, nullptr);
+    EXPECT_NE(find(col, NodeType::ColumnDefinition), nullptr);
+}
+
 TEST_F(ExprHardeningTest, AlterColumnSetDropNotNull) {
     // SET NOT NULL / DROP NOT NULL are recorded as flags on the action node.
     auto* a1 = parse("ALTER TABLE t ALTER COLUMN c SET NOT NULL");


### PR DESCRIPTION
## Summary

`ALTER TABLE ... ADD` unconditionally parsed a column definition, so `ADD PRIMARY KEY` / `UNIQUE` / `CHECK` / `FOREIGN KEY` (and `ADD CONSTRAINT ...`) were misparsed.

This dispatches on the leading keyword: `PRIMARY` / `UNIQUE` / `CHECK` / `FOREIGN` / `CONSTRAINT` go through the existing `parse_table_constraint` — producing the **same constraint nodes as in CREATE TABLE**, which the analyzer already understands — while everything else remains `ADD [COLUMN] <definition>`. A column name is never one of those reserved keywords, so the two cases are unambiguous.

## Testing

Adds `AlterTableAddConstraint`, covering `ADD PRIMARY KEY` / `UNIQUE` / `CHECK` (with captured expression text) / `FOREIGN KEY` and the still-working `ADD COLUMN`. Full 37-test suite green, clean under ASan + UBSan.

## Why

Enables the analyzer to implement `ALTER TABLE ADD CONSTRAINT`, reusing the same `collect_*` logic it already applies to CREATE TABLE constraints.