### PR TITLE
parser: capture constraint names and parse DROP CONSTRAINT

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -717,16 +717,18 @@ ast::ASTNode* Parser::parse_table_constraint() {
     if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
     
     ast::ASTNode* constraint = nullptr;
-    
-    // Optional CONSTRAINT name
+
+    // Optional CONSTRAINT <name>: capture the name so it can be attached to the
+    // constraint node below (needed for ALTER TABLE DROP CONSTRAINT <name>).
+    std::string_view constraint_name;
     if (current_token_ && current_token_->keyword_id == db25::Keyword::CONSTRAINT) {
         advance();
-        // Skip constraint name for now
         if (current_token_ && current_token_->type == tokenizer::TokenType::Identifier) {
+            constraint_name = current_token_->value;
             advance();
         }
     }
-    
+
     if (current_token_ && current_token_->keyword_id == db25::Keyword::PRIMARY) {
         advance();
         if (current_token_ && current_token_->keyword_id == db25::Keyword::KEY) {
@@ -852,6 +854,12 @@ ast::ASTNode* Parser::parse_table_constraint() {
                 parenthesis_depth_--;
             }
         }
+    }
+
+    // Attach the optional constraint name (stored on schema_name so it does not
+    // collide with primary_text, which a CHECK uses for its expression text).
+    if (constraint != nullptr && !constraint_name.empty()) {
+        constraint->schema_name = copy_to_arena(constraint_name);
     }
 
     return constraint;
@@ -1034,11 +1042,37 @@ ast::ASTNode* Parser::parse_alter_table_full() {
     } else if (current_token_ && current_token_->keyword_id == db25::Keyword::DROP) {
         advance();
         action->primary_text = copy_to_arena("DROP");
-        
+
+        // DROP CONSTRAINT <name> [CASCADE|RESTRICT]: flagged distinctly from
+        // DROP COLUMN. The name is attached as an Identifier child.
+        if (current_token_ && current_token_->keyword_id == db25::Keyword::CONSTRAINT) {
+            advance(); // consume CONSTRAINT
+            action->semantic_flags |= 0x20;  // DROP CONSTRAINT flag
+            if (current_token_ && current_token_->type == tokenizer::TokenType::Identifier) {
+                auto* nm = arena_.allocate<ast::ASTNode>();
+                new (nm) ast::ASTNode(ast::NodeType::Identifier);
+                nm->node_id = next_node_id_++;
+                nm->primary_text = copy_to_arena(current_token_->value);
+                nm->parent = action;
+                action->first_child = nm;
+                action->child_count = 1;
+                advance();
+            }
+            if (current_token_ && current_token_->keyword_id == db25::Keyword::CASCADE) {
+                action->semantic_flags |= 0x01;  // CASCADE
+                advance();
+            } else if (current_token_ &&
+                       current_token_->keyword_id == db25::Keyword::RESTRICT) {
+                action->semantic_flags |= 0x02;  // RESTRICT
+                advance();
+            }
+            return alter_node;
+        }
+
         if (current_token_ && current_token_->keyword_id == db25::Keyword::COLUMN) {
             advance(); // optional COLUMN keyword
         }
-        
+
         // Get column name
         if (current_token_ && current_token_->type == tokenizer::TokenType::Identifier) {
             auto* col = arena_.allocate<ast::ASTNode>();

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -528,6 +528,43 @@ TEST_F(ExprHardeningTest, AlterTableAddConstraint) {
     EXPECT_NE(find(col, NodeType::ColumnDefinition), nullptr);
 }
 
+TEST_F(ExprHardeningTest, NamedConstraintCapturesName) {
+    // The optional CONSTRAINT <name> is captured on the constraint node's
+    // schema_name (not primary_text, which a CHECK uses for its expression).
+    auto* ast = parse("CREATE TABLE t (a INTEGER, CONSTRAINT uq_a UNIQUE (a))");
+    ASSERT_NE(ast, nullptr);
+    auto* u = find(ast, NodeType::UniqueConstraint);
+    ASSERT_NE(u, nullptr);
+    EXPECT_EQ(u->schema_name, "uq_a");
+
+    auto* ck = parse("CREATE TABLE t (a INTEGER, CONSTRAINT ck_a CHECK (a > 0))");
+    ASSERT_NE(ck, nullptr);
+    auto* c = find(ck, NodeType::CheckConstraint);
+    ASSERT_NE(c, nullptr);
+    EXPECT_EQ(c->schema_name, "ck_a");     // name
+    EXPECT_EQ(c->primary_text, "a > 0");   // expression, unaffected
+}
+
+TEST_F(ExprHardeningTest, AlterDropConstraint) {
+    // DROP CONSTRAINT <name> flags the action (0x20) and names it as an
+    // Identifier child, distinct from DROP COLUMN.
+    auto* ast = parse("ALTER TABLE t DROP CONSTRAINT uq_a");
+    ASSERT_NE(ast, nullptr);
+    auto* act = find(ast, NodeType::AlterTableAction);
+    ASSERT_NE(act, nullptr);
+    EXPECT_TRUE(act->semantic_flags & 0x20);
+    auto* nm = find(act, NodeType::Identifier);
+    ASSERT_NE(nm, nullptr);
+    EXPECT_EQ(nm->primary_text, "uq_a");
+
+    // DROP COLUMN is still not flagged as a constraint drop.
+    auto* col = parse("ALTER TABLE t DROP COLUMN a");
+    ASSERT_NE(col, nullptr);
+    auto* act2 = find(col, NodeType::AlterTableAction);
+    ASSERT_NE(act2, nullptr);
+    EXPECT_FALSE(act2->semantic_flags & 0x20);
+}
+
 TEST_F(ExprHardeningTest, AlterColumnSetDropNotNull) {
     // SET NOT NULL / DROP NOT NULL are recorded as flags on the action node.
     auto* a1 = parse("ALTER TABLE t ALTER COLUMN c SET NOT NULL");


### PR DESCRIPTION
## Summary

Two related gaps for named constraints:

- `parse_table_constraint` consumed an optional `CONSTRAINT <name>` prefix but **threw the name away**. Now it captures the name and attaches it to the constraint node's `schema_name` (kept off `primary_text`, which a CHECK uses for its expression text). This applies in CREATE TABLE and ALTER TABLE ADD CONSTRAINT alike.
- `ALTER TABLE DROP` always parsed a column name, so `DROP CONSTRAINT <name>` was misparsed as DROP COLUMN. Now it's recognized: the action is flagged (`0x20`) and the constraint name is attached as an Identifier child, with optional CASCADE/RESTRICT. `DROP COLUMN` is unchanged.

## Testing

Adds parser tests for the captured name (UNIQUE and CHECK — the latter verifying the expression text is unaffected) and for `DROP CONSTRAINT` (flag + name) vs a plain `DROP COLUMN`. Full 37-test suite green, clean under ASan + UBSan.

## Why

Enables the analyzer to store named constraints in the catalog and implement `ALTER TABLE DROP CONSTRAINT <name>`.