### PR TITLE
parser: capture derived-table column-alias lists "(SELECT ...) AS t (a, b)"

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1558,6 +1558,74 @@ ast::ASTNode* Parser::parse_table_reference() {
         advance();
     }
 
+    // Optional column-alias list for a DERIVED TABLE: "(SELECT ...) AS t (a, b)".
+    // Standard SQL renames the relation's output columns. Without this the whole
+    // "(...)" was left unconsumed: at statement level the trailing tokens were
+    // silently tolerated (the aliases dropped), but inside an expression
+    // subquery the stray '(' broke ')' matching and failed the parse. Capture it
+    // as a ColumnList of Identifier nodes (the same shape a CTE column list
+    // uses).
+    //
+    // Restricted to a subquery ref: parse_table_reference is shared with the
+    // INSERT/UPDATE/DELETE target path, where "t (a, b)" is the INSERT target
+    // column list (parsed by the DML parser), not an alias list. Base-table
+    // column aliases ("FROM t x(a,b)") are rare and left as a follow-up. Guard
+    // on the paren being followed by an identifier so a "(1, 2)" is never taken
+    // as a column list.
+    if (ref_node->node_type == ast::NodeType::Subquery &&
+        current_token_ && current_token_->type == tokenizer::TokenType::Delimiter &&
+        current_token_->value == "(" && peek_token_ &&
+        peek_token_->type == tokenizer::TokenType::Identifier) {
+        parenthesis_depth_++;
+        advance();  // consume '('
+
+        auto* col_list = arena_.allocate<ast::ASTNode>();
+        new (col_list) ast::ASTNode(ast::NodeType::ColumnList);
+        col_list->node_id = next_node_id_++;
+
+        ast::ASTNode* last_col = nullptr;
+        while (current_token_ &&
+               current_token_->type == tokenizer::TokenType::Identifier) {
+            auto* id = arena_.allocate<ast::ASTNode>();
+            new (id) ast::ASTNode(ast::NodeType::Identifier);
+            id->node_id = next_node_id_++;
+            id->primary_text = copy_to_arena(current_token_->value);
+            id->parent = col_list;
+            if (last_col) {
+                last_col->next_sibling = id;
+            } else {
+                col_list->first_child = id;
+            }
+            last_col = id;
+            col_list->child_count++;
+            advance();  // consume the identifier
+            if (current_token_ && current_token_->value == ",") {
+                advance();  // consume ',' and read the next column name
+                continue;
+            }
+            break;
+        }
+
+        if (current_token_ && current_token_->value == ")") {
+            if (parenthesis_depth_ > 0) parenthesis_depth_--;
+            advance();  // consume ')'
+        }
+
+        // Attach as the LAST child so consumers that read the derived table's
+        // inner query block (via find_child / first_child) are unaffected.
+        col_list->parent = ref_node;
+        if (ref_node->first_child) {
+            ast::ASTNode* c = ref_node->first_child;
+            while (c->next_sibling) {
+                c = c->next_sibling;
+            }
+            c->next_sibling = col_list;
+        } else {
+            ref_node->first_child = col_list;
+        }
+        ref_node->child_count++;
+    }
+
     return ref_node;
 }
 

--- a/tests/test_parser_select.cpp
+++ b/tests/test_parser_select.cpp
@@ -623,3 +623,55 @@ TEST_F(SelectParserTest, DerivedTableStillParsesAsSubquery) {
     ASSERT_NE(subquery, nullptr) << "derived table must parse as a Subquery";
     EXPECT_EQ(subquery->schema_name, "x");  // alias preserved
 }
+
+TEST_F(SelectParserTest, DerivedTableColumnAliasListCaptured) {
+    // "( SELECT ... ) AS t (a, b)" renames the derived table's output columns.
+    // The list must be CONSUMED (no trailing input) and CAPTURED as a ColumnList
+    // of Identifier nodes under the Subquery - previously it was silently dropped.
+    auto result = parser.parse("SELECT * FROM (SELECT 1) AS t(a, b)");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(parser.has_trailing_input()) << "column-alias list must be consumed";
+
+    auto* from = find_child_by_type(result.value(), NodeType::FromClause);
+    ASSERT_NE(from, nullptr);
+    auto* subquery = find_child_by_type(from, NodeType::Subquery);
+    ASSERT_NE(subquery, nullptr);
+    EXPECT_EQ(subquery->schema_name, "t");
+
+    auto* col_list = find_child_by_type(subquery, NodeType::ColumnList);
+    ASSERT_NE(col_list, nullptr) << "column aliases must be captured, not dropped";
+    EXPECT_EQ(count_children(col_list), 2);
+    auto* first = col_list->get_first_child();
+    ASSERT_NE(first, nullptr);
+    EXPECT_EQ(first->node_type, NodeType::Identifier);
+    EXPECT_EQ(first->primary_text, "a");
+    ASSERT_NE(first->get_next_sibling(), nullptr);
+    EXPECT_EQ(first->get_next_sibling()->primary_text, "b");
+
+    // The inner SELECT must still be reachable as a child (consumers read it).
+    EXPECT_NE(find_child_by_type(subquery, NodeType::SelectStmt), nullptr);
+}
+
+TEST_F(SelectParserTest, DerivedTableColumnAliasInsideSubqueryParses) {
+    // Regression: the same construct nested inside an expression subquery used to
+    // fail to parse - the unconsumed "(a)" broke ")" matching for the outer
+    // subquery. Both the IN-subquery and scalar-subquery positions must parse.
+    auto a = parser.parse("SELECT NULL IN (SELECT * FROM (SELECT 1) AS t(a))");
+    EXPECT_TRUE(a.has_value()) << "column-alias list inside an IN-subquery must parse";
+
+    parser.reset();
+    auto b = parser.parse("SELECT (SELECT max(x) FROM (SELECT 1) AS t(x))");
+    EXPECT_TRUE(b.has_value()) << "column-alias list inside a scalar subquery must parse";
+}
+
+TEST_F(SelectParserTest, InsertTargetColumnListNotMistakenForAlias) {
+    // Guard: parse_table_reference is shared with the INSERT path. The restriction
+    // to derived-table (Subquery) refs must leave an INSERT's target column list
+    // "(a, b, c)" for the DML parser, not steal it as an alias list.
+    auto r = parser.parse("INSERT INTO tbl (a, b, c) VALUES (1, 2, 3)");
+    ASSERT_TRUE(r.has_value());
+    EXPECT_EQ(r.value()->node_type, NodeType::InsertStmt);
+    auto* col_list = find_child_by_type(r.value(), NodeType::ColumnList);
+    ASSERT_NE(col_list, nullptr) << "INSERT target column list must be preserved";
+    EXPECT_EQ(count_children(col_list), 3);
+}


### PR DESCRIPTION
## What

A derived table may rename its output columns with a parenthesized column-alias list — `(SELECT …) AS t (a, b)`. `parse_table_reference` consumed the table alias but **never the column-alias list**, with three consequences, all violating "no silent wrong results":

- **Data loss** — the column names were dropped from the AST entirely.
- **Silent wrong parse** at statement level — the unconsumed `(a, b)` was left as trailing input and silently tolerated, so the statement "succeeded" with the aliases missing (and `(VALUES …) AS t(a,b)` lost even more).
- **Hard failure** inside an expression subquery — e.g. `SELECT x IN (SELECT * FROM (SELECT 1) AS t(a))` — where the stray `(` broke `)` matching for the outer subquery and failed the whole parse. This shape is common in the sqllogictest corpus.

## Fix

After the alias name, parse a `( ident [, ident]* )` column-alias list and attach it as a **`ColumnList` of `Identifier` nodes** — the same representation a CTE column list uses, and one the binder already reads. The inner query block stays `first_child`, so consumers that reach it via `find_child` / `first_child` are unaffected.

Scoped precisely to avoid collateral damage:
- **Restricted to a derived-table (`Subquery`) ref** — `parse_table_reference` is shared with the INSERT/UPDATE/DELETE target path, where `t (a, b)` is the target column list, not an alias list.
- **The paren must be followed by an identifier**, so a trailing `(1, 2)` (an unsupported table-function argument list) is left untouched.

## Tests

New `SelectParserTest` cases:
- `DerivedTableColumnAliasListCaptured` — the list is consumed (no trailing input) and captured (two `Identifier` children `a`, `b`); the inner SELECT stays reachable.
- `DerivedTableColumnAliasInsideSubqueryParses` — the nested IN- and scalar-subquery positions parse.
- `InsertTargetColumnListNotMistakenForAlias` — the INSERT target list is preserved (regression guard for the shared path).

**Full parser suite 37/37.** The analyzer (5/5) and logical-plan/binder + optimizer (3/3) suites were rebuilt against this change and stay green — the new `ColumnList` child is transparent to existing consumers.

## Provenance & follow-up

Found via a **sqllogictest differential corpus** run against the DB25 frontend. Separately, `(VALUES …)` as a derived table in FROM is a **distinct pre-existing gap** (the FROM item is dropped) — left to a follow-up PR; this change is scoped to the column-alias list only.