### PR TITLE
parser: recognize (VALUES ...) as a derived table in FROM

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1419,7 +1419,8 @@ ast::ASTNode* Parser::parse_table_reference() {
         const bool is_derived_table =
             peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
             (peek_token_->keyword_id == db25::Keyword::SELECT ||
-             peek_token_->keyword_id == db25::Keyword::WITH);
+             peek_token_->keyword_id == db25::Keyword::WITH ||
+             peek_token_->keyword_id == db25::Keyword::VALUES);
         // A parenthesized join group begins with something that itself begins a
         // table reference: an identifier (table name) or a nested '('.
         const bool is_join_group =
@@ -1438,11 +1439,22 @@ ast::ASTNode* Parser::parse_table_reference() {
             subquery_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::IsSubquery);
 
             push_context(ParseContext::SUBQUERY);
-            auto* inner = (current_token_ &&
-                           current_token_->type == tokenizer::TokenType::Keyword &&
-                           current_token_->keyword_id == db25::Keyword::WITH)
-                              ? parse_with_statement()
-                              : parse_select_stmt();
+            // The derived-table body is a SELECT, a WITH ... SELECT, or a VALUES
+            // list ( "(VALUES (1, 2), (3, 4)) AS t (a, b)" ). Dispatch on the
+            // leading keyword; without the VALUES arm the "(" matched neither a
+            // derived table nor a join group, so the whole FROM item was dropped.
+            ast::ASTNode* inner = nullptr;
+            if (current_token_ &&
+                current_token_->type == tokenizer::TokenType::Keyword &&
+                current_token_->keyword_id == db25::Keyword::WITH) {
+                inner = parse_with_statement();
+            } else if (current_token_ &&
+                       current_token_->type == tokenizer::TokenType::Keyword &&
+                       current_token_->keyword_id == db25::Keyword::VALUES) {
+                inner = parse_values_stmt();
+            } else {
+                inner = parse_select_stmt();
+            }
             pop_context();
             if (inner) {
                 inner->parent = subquery_node;

--- a/tests/test_parser_select.cpp
+++ b/tests/test_parser_select.cpp
@@ -675,3 +675,30 @@ TEST_F(SelectParserTest, InsertTargetColumnListNotMistakenForAlias) {
     ASSERT_NE(col_list, nullptr) << "INSERT target column list must be preserved";
     EXPECT_EQ(count_children(col_list), 3);
 }
+
+TEST_F(SelectParserTest, ValuesDerivedTableInFrom) {
+    // "( VALUES (..), (..) ) AS t" is a derived table whose body is a VALUES
+    // list. Previously the "(" matched neither a derived table (only SELECT/WITH
+    // were recognized) nor a join group, so the ENTIRE FROM clause was silently
+    // dropped. It must now parse to FromClause -> Subquery -> ValuesStmt.
+    auto result = parser.parse("SELECT * FROM (VALUES (1, 2), (3, 4)) AS t");
+    ASSERT_TRUE(result.has_value());
+    EXPECT_FALSE(parser.has_trailing_input());
+
+    auto* from = find_child_by_type(result.value(), NodeType::FromClause);
+    ASSERT_NE(from, nullptr) << "FROM clause must not be dropped for a VALUES source";
+
+    auto* subquery = find_child_by_type(from, NodeType::Subquery);
+    ASSERT_NE(subquery, nullptr) << "VALUES source must parse as a derived table";
+    EXPECT_EQ(subquery->schema_name, "t");
+    EXPECT_NE(find_child_by_type(subquery, NodeType::ValuesStmt), nullptr)
+        << "derived-table body must be a ValuesStmt";
+}
+
+TEST_F(SelectParserTest, ValuesDerivedTableInsideSubqueryParses) {
+    // Regression: a VALUES derived table nested inside an expression subquery used
+    // to fail to parse outright (the unrecognized "(" cascaded into a paren
+    // mismatch on the outer subquery).
+    auto r = parser.parse("SELECT NULL IN (SELECT * FROM (VALUES (1)) AS t)");
+    EXPECT_TRUE(r.has_value()) << "VALUES derived table inside an IN-subquery must parse";
+}


### PR DESCRIPTION
## What

A VALUES list may stand in as a derived table: `( VALUES (1, 2), (3, 4) ) AS t`. The FROM table-reference parser recognized a parenthesized derived table **only when the `(` was followed by `SELECT` or `WITH`**. For `VALUES` the `(` matched neither a derived table nor a parenthesized join group, so it was left unconsumed and the **entire FROM clause was silently dropped**:

- `SELECT * FROM (VALUES (1,1))` parsed to a `SelectStmt` with **no `FromClause` at all** — a silent wrong parse.
- The same shape nested inside an expression subquery (`… IN (SELECT * FROM (VALUES (1)) AS t)`) failed to parse outright.

## Fix

Add `VALUES` to the derived-table lookahead and dispatch the inner body to `parse_values_stmt()`, mirroring the existing `SELECT` / `WITH` arms. The result is a faithful `Subquery → ValuesStmt` subtree carrying the rows, with the table alias preserved.

## Downstream safety

The analyzer resolves a derived table's columns via `find_child(Subquery, SelectStmt)` and the binder via a **null-checked** `subquery_body()`, so a VALUES body (no `SelectStmt`) degrades to an **unbound-but-not-dropped** relation rather than crashing. Verified: the analyzer analyzes a VALUES-derived table without crashing. Fully **binding** a VALUES derived table's columns is a separate semantic follow-up.

## Tests

New `SelectParserTest` cases:
- `ValuesDerivedTableInFrom` — parses to `FromClause → Subquery → ValuesStmt`, alias preserved, no trailing input.
- `ValuesDerivedTableInsideSubqueryParses` — the nested IN-subquery position parses.

**Full parser suite 37/37.** Analyzer (5/5) and logical-plan binder + optimizer (3/3) rebuilt against this change stay green.

## Provenance

Found via a **sqllogictest differential corpus** run against the DB25 frontend. Independent of #43 (derived-table column-alias lists); the two compose — with both, `(VALUES (1,1)) AS t(a,b)` parses *and* captures its column aliases.