### PR TITLE
parser: bound parenthesized-join-group recursion in FROM (fix stack overflow)

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1405,6 +1405,19 @@ ast::ASTNode* Parser::parse_identifier() {
 }
 
 ast::ASTNode* Parser::parse_table_reference() {
+    // A parenthesized join group `( a JOIN b )` recurses here via
+    // parse_from_clause() (see the is_join_group branch below), so a `(`-heavy
+    // FROM item like `FROM ((((...` would otherwise drive unbounded native
+    // recursion and overflow the stack. Unlike parse_select_stmt, this function
+    // and parse_from_clause carry no guard, so bound the recursion here (the one
+    // re-entrant point of the FROM cycle). The guard must be a plain
+    // function-scope local (not an if-init variable, which would be destroyed at
+    // the end of the if and decrement the depth before the recursive body runs),
+    // so the increment persists across the nested parse_from_clause() call.
+    DepthGuard guard(this);
+    if (!guard.is_valid()) {
+        return nullptr;
+    }
     if (!current_token_) {
         return nullptr;
     }

--- a/tests/security/test_depth_guard.cpp
+++ b/tests/security/test_depth_guard.cpp
@@ -37,6 +37,22 @@ std::string generate_nested_subqueries(int depth) {
     return sql.str();
 }
 
+// Generate deeply nested parenthesised join groups in FROM:
+// SELECT 1 FROM (((( ... t ... )))). Each '(' whose next token begins a table
+// reference is a join group and recurses parse_from_clause -> parse_table_reference.
+std::string generate_nested_from_groups(int depth) {
+    std::stringstream sql;
+    sql << "SELECT 1 FROM ";
+    for (int i = 0; i < depth; ++i) {
+        sql << "(";
+    }
+    sql << "t";
+    for (int i = 0; i < depth; ++i) {
+        sql << ")";
+    }
+    return sql.str();
+}
+
 // Generate deeply nested parenthesised expressions: SELECT (1 + (1 + ( ... 1 ... )))
 std::string generate_nested_expr(int depth) {
     std::stringstream sql;
@@ -73,6 +89,28 @@ TEST(DepthGuard, DeeplyNestedSubqueriesRejected) {
     auto result = parser.parse(sql);
     ASSERT_FALSE(result.has_value())
         << "Deeply nested subqueries must be rejected by the DepthGuard";
+    EXPECT_EQ(result.error().message, kDepthError);
+}
+
+// A modestly nested parenthesised FROM join group stays under the limit and parses.
+TEST(DepthGuard, ShallowNestedFromGroupParses) {
+    Parser parser;
+    auto result = parser.parse(generate_nested_from_groups(5));
+    ASSERT_TRUE(result.has_value())
+        << "Shallow FROM join group should parse, got error: " << result.error().message;
+}
+
+// Deeply nested parenthesised FROM join groups (`FROM ((((...`) previously drove
+// unbounded native recursion (parse_table_reference <-> parse_from_clause) and
+// overflowed the stack. They must now be rejected gracefully by the DepthGuard.
+TEST(DepthGuard, DeeplyNestedFromGroupsRejected) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+    const std::string sql = generate_nested_from_groups(static_cast<int>(limit) * 3);
+
+    auto result = parser.parse(sql);
+    ASSERT_FALSE(result.has_value())
+        << "Deeply nested FROM join groups must be rejected by the DepthGuard";
     EXPECT_EQ(result.error().message, kDepthError);
 }
 


### PR DESCRIPTION
## What

`SELECT 1 FROM ((((…` (a `(`-heavy FROM item) crashed the parser with a **stack overflow**. This bounds the recursion so it's rejected gracefully instead.

## Why

A `(` in table-reference position whose next token begins a table reference is a parenthesized join group `( a JOIN b )`, parsed by recursing `parse_table_reference` → `parse_from_clause` → `parse_table_reference`. Neither of those two functions carried a `DepthGuard` (only `parse_select_stmt` / `parse_with_statement` do), so each `(` pushed one native stack frame with no bound → SIGSEGV. ASan confirms an unbounded `parse_table_reference ↔ parse_from_clause` cycle. This violates the "never crash on any input" invariant.

## How

Add a `DepthGuard` at the one re-entrant point of the cycle, `parse_table_reference`.

**Subtlety worth a look in review:** the guard must be a plain function-scope local:

```cpp
DepthGuard guard(this);
if (!guard.is_valid()) return nullptr;
```

An `if (const DepthGuard guard(this); !guard.is_valid()) …` init-statement variable is destroyed at the *end of the `if`*, decrementing the depth *before* the recursive body runs — so the count never accumulates and the guard is useless for recursion. (My first cut used that form and still overflowed under ASan; note that the same ineffective init-statement form appears in the DDL parsers, harmless only because those don't deeply self-recurse.) As a function-scope local, the increment persists across the nested `parse_from_clause()` call, so the existing `max_depth` bound applies and a too-deep FROM is rejected with `"Maximum recursion depth exceeded"`.

## Tests

`tests/security/test_depth_guard.cpp`:
- a shallow nested FROM join group (`FROM (((((t)))))`) still parses;
- a FROM group nested past the limit is rejected gracefully — no crash.

Verified under AddressSanitizer at depths up to 500k: graceful rejection, no stack overflow (previously SIGSEGV by ~20k). Full parser suite **37/37 green**.

Surfaced by a robustness audit of the parser layer.
