### PR TITLE
parser: fix mixed-case WHEN detection and reject CASE without END

### DIFF
--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -982,10 +982,17 @@ ast::ASTNode* Parser::parse_case_expression() {
     ast::ASTNode* last_child = nullptr;
     ast::ASTNode* search_expr = nullptr;
     
-    // Check if this is a searched CASE (has expression after CASE)
-    if ((current_token_ && current_token_->type != tokenizer::TokenType::Keyword) ||
-        (current_token_->value != "WHEN" && current_token_->value != "when")) {
-        // Parse the search expression
+    // A searched CASE (`CASE WHEN ...`) has no operand between CASE and the first
+    // WHEN; a simple CASE (`CASE x WHEN ...`) does. Detect the WHEN by keyword id
+    // - not by comparing the token text to "WHEN"/"when", which missed a
+    // mixed-case `When` (SQL keywords are case-insensitive) and mis-parsed it as a
+    // simple-CASE operand, losing every branch. Guarding on the keyword id also
+    // avoids dereferencing a null current token.
+    const bool at_when = current_token_ != nullptr &&
+                         current_token_->type == tokenizer::TokenType::Keyword &&
+                         current_token_->keyword_id == db25::Keyword::WHEN;
+    if (!at_when) {
+        // Parse the search expression (the simple-CASE operand).
         search_expr = parse_expression(0);
         if (search_expr) {
             search_expr->parent = case_node;
@@ -1064,12 +1071,18 @@ ast::ASTNode* Parser::parse_case_expression() {
         }
     }
     
-    // Expect END
+    // Expect END. A CASE without its closing END is malformed; error rather than
+    // silently accepting a truncated expression (parse() surfaces the recorded
+    // error once the null unwinds to the top).
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         (current_token_->keyword_id == db25::Keyword::END)) {
         advance(); // consume END
+    } else {
+        error("expected END to close CASE expression");
+        pop_context();
+        return nullptr;
     }
-    
+
     pop_context();
     return case_node;
 }

--- a/tests/test_case_expr.cpp
+++ b/tests/test_case_expr.cpp
@@ -168,3 +168,33 @@ TEST_F(CaseExprTest, CaseWithNull) {
     auto* case_expr = find_node_by_type(ast, NodeType::CaseExpr);
     ASSERT_NE(case_expr, nullptr);
 }
+// A mixed-case `When` must be recognised as the searched-CASE keyword (SQL
+// keywords are case-insensitive): the CASE has no operand and its first child is
+// the WHEN branch, not a bogus `Identifier("When")` that dropped every branch.
+TEST_F(CaseExprTest, MixedCaseWhenIsSearchedCase) {
+    auto* ast = parse("SELECT CASE When x = 1 THEN 'a' ELSE 'b' END FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* case_expr = find_node_by_type(ast, NodeType::CaseExpr);
+    ASSERT_NE(case_expr, nullptr);
+    // Searched CASE: first child is the WHEN branch (a BinaryExpr "WHEN"), and no
+    // stray Identifier operand was captured.
+    ASSERT_NE(case_expr->first_child, nullptr);
+    EXPECT_EQ(case_expr->first_child->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(std::string(case_expr->first_child->primary_text), "WHEN");
+    // The whole input is consumed (the FROM is parsed, nothing dropped).
+    EXPECT_NE(find_node_by_type(ast, NodeType::FromClause), nullptr);
+}
+
+// A lower-case `when`/`then`/`else`/`end` parses the same (regression guard).
+TEST_F(CaseExprTest, LowerCaseKeywordsParse) {
+    auto* ast = parse("SELECT case when x = 1 then 'a' else 'b' end FROM t");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_NE(find_node_by_type(ast, NodeType::CaseExpr), nullptr);
+}
+
+// A CASE missing its closing END is malformed and must be rejected, not silently
+// accepted as a truncated expression.
+TEST_F(CaseExprTest, MissingEndIsRejected) {
+    auto* ast = parse("SELECT CASE WHEN a THEN b FROM t");
+    EXPECT_EQ(ast, nullptr);
+}


### PR DESCRIPTION
## What

Two CASE-expression parsing defects (first of a cluster surfaced by a parser robustness audit):

1. **Mixed-case searched-CASE keyword.** The "simple vs searched CASE" test compared the token *text* to `"WHEN"`/`"when"`, so `CASE When x = 1 THEN 'a' ELSE 'b' END` was treated as a *simple* CASE whose operand is a bogus `Identifier("When")`; the WHEN loop (which correctly keys on `keyword_id`) then matched nothing and **every branch was dropped**. Now detects WHEN by `keyword_id`, like the loop — SQL keywords are case-insensitive. This also removes a **latent null-dereference**: the old second disjunct read `current_token_->value` with no null guard.

2. **Missing END silently accepted.** `SELECT CASE WHEN a THEN b FROM t` returned a truncated `CaseExpr` and parsing continued into `FROM`. Now emits a recoverable error so the malformed input is rejected instead of yielding a structurally under-specified node the binder would treat as complete.

## Before / after

`CASE When x = 1 THEN 'a' ELSE 'b' END` — before: `CaseExpr → Identifier('When')` (branches lost, 9 trailing tokens); after: proper searched `CaseExpr → BinaryExpr('WHEN') → …`, whole input consumed.

`SELECT CASE WHEN a THEN b FROM t` — before: parsed "successfully"; after: `PARSE ERROR: expected END to close CASE expression`.

## Tests

`tests/test_case_expr.cpp`: mixed-case `When` parses as a searched CASE (first child is the WHEN branch; FROM still parsed); all-lowercase `case/when/then/else/end` still parses (regression guard); a CASE missing END is rejected. Full suite **37/37 green**.

Part of the parser-layer robustness pass; the set-operation and `IN`/`IS DISTINCT FROM` silent-drop findings from the same audit follow in separate PRs.
