### PR TITLE
parser: parse IS [NOT] DISTINCT FROM (null-safe comparison)

### DIFF
--- a/include/db25/ast/node_types.hpp
+++ b/include/db25/ast/node_types.hpp
@@ -229,7 +229,12 @@ enum class BinaryOp : uint8_t {
     Is,
     IsNot,
     In,
-    NotIn
+    NotIn,
+    // Null-safe comparison: `a IS DISTINCT FROM b` / `a IS NOT DISTINCT FROM b`.
+    // Always a plain boolean, never NULL (two NULLs are "not distinct"; a NULL
+    // and a non-NULL are "distinct"). Appended to preserve existing enum values.
+    IsDistinctFrom,
+    IsNotDistinctFrom
 };
 
 /**

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -885,6 +885,41 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
                     continue;
                 }
 
+                // IS [NOT] DISTINCT FROM <expr> -- a null-safe comparison that is
+                // ALWAYS a plain boolean, never NULL (two NULLs are "not distinct";
+                // a NULL and a non-NULL are "distinct"). Represented as a BinaryExpr
+                // whose operator text the binder maps to
+                // BinaryOp::Is[Not]DistinctFrom. Previously the DISTINCT FROM tail
+                // was silently dropped, leaving the predicate as its bare left
+                // operand (a silent wrong result).
+                if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                    current_token_->keyword_id == db25::Keyword::DISTINCT) {
+                    advance(); // consume DISTINCT
+                    if (!current_token_ || current_token_->type != tokenizer::TokenType::Keyword ||
+                        current_token_->keyword_id != db25::Keyword::FROM) {
+                        error("expected FROM after IS [NOT] DISTINCT");
+                        return nullptr;
+                    }
+                    advance(); // consume FROM
+                    ast::ASTNode* rhs = parse_expression(precedence + 1);
+                    if (!rhs) {
+                        error("expected expression after IS [NOT] DISTINCT FROM");
+                        return nullptr;
+                    }
+                    auto* dist_node = arena_.allocate<ast::ASTNode>();
+                    new (dist_node) ast::ASTNode(ast::NodeType::BinaryExpr);
+                    dist_node->node_id = next_node_id_++;
+                    dist_node->primary_text =
+                        copy_to_arena(is_not ? "IS NOT DISTINCT FROM" : "IS DISTINCT FROM");
+                    left->parent = dist_node;
+                    dist_node->first_child = left;
+                    left->next_sibling = rhs;
+                    rhs->parent = dist_node;
+                    dist_node->child_count = 2;
+                    left = dist_node;
+                    continue;
+                }
+
                 // Expect NULL
                 if (!current_token_ || current_token_->type != tokenizer::TokenType::Keyword ||
                     (current_token_->value != "NULL" && current_token_->value != "null")) {

--- a/tests/test_parser_expr_hardening.cpp
+++ b/tests/test_parser_expr_hardening.cpp
@@ -351,6 +351,41 @@ TEST_F(ExprHardeningTest, IsNullStillParsesAfterBooleanTest) {
     EXPECT_EQ(pred->primary_text, "IS NOT NULL");
 }
 
+// ---- IS [NOT] DISTINCT FROM (null-safe comparison) ------------------------
+
+TEST_F(ExprHardeningTest, IsDistinctFromBuildsBinaryExpr) {
+    // `x IS DISTINCT FROM y` is a binary comparison over both operands, not a
+    // dropped predicate (previously the DISTINCT FROM tail was silently lost,
+    // leaving just `x`).
+    auto* ast = parse("SELECT * FROM t WHERE x IS DISTINCT FROM y");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(pred->primary_text, "IS DISTINCT FROM");
+    ASSERT_NE(pred->first_child, nullptr);
+    EXPECT_EQ(pred->first_child->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(pred->first_child->primary_text, "x");
+    ASSERT_NE(pred->first_child->next_sibling, nullptr);
+    EXPECT_EQ(pred->first_child->next_sibling->node_type, NodeType::ColumnRef);
+    EXPECT_EQ(pred->first_child->next_sibling->primary_text, "y");
+}
+
+TEST_F(ExprHardeningTest, IsNotDistinctFromBuildsBinaryExpr) {
+    auto* ast = parse("SELECT * FROM t WHERE x IS NOT DISTINCT FROM y");
+    ASSERT_NE(ast, nullptr);
+    auto* pred = where_predicate(ast);
+    ASSERT_NE(pred, nullptr);
+    EXPECT_EQ(pred->node_type, NodeType::BinaryExpr);
+    EXPECT_EQ(pred->primary_text, "IS NOT DISTINCT FROM");
+}
+
+TEST_F(ExprHardeningTest, IsDistinctWithoutFromIsRejected) {
+    // `IS DISTINCT` with no FROM is malformed and must not silently drop.
+    auto* ast = parse("SELECT * FROM t WHERE x IS DISTINCT");
+    EXPECT_EQ(ast, nullptr);
+}
+
 // ---- ILIKE (case-insensitive LIKE) ----------------------------------------
 
 TEST_F(ExprHardeningTest, IlikeBuildsLikeExpr) {


### PR DESCRIPTION
## What

`x IS [NOT] DISTINCT FROM y` is valid, null-safe-comparison SQL, but the `IS` handler only recognized `IS [NOT] NULL / TRUE / FALSE / UNKNOWN` and **silently dropped** the `DISTINCT FROM` tail — leaving the predicate as its bare left operand `x`, so the `WHERE` effectively vanished (a silent wrong result).

The **parser leg** of full `IS [NOT] DISTINCT FROM` support (the user asked for end-to-end support; analyzer and binder legs follow in their repos).

## How

- Parse it into a `BinaryExpr` whose operator text is `"IS DISTINCT FROM"` / `"IS NOT DISTINCT FROM"` — the same text-carried-operator convention the binder's `map_binary_op` already uses for every other comparison.
- Append two `ast::BinaryOp` enum values, `IsDistinctFrom` / `IsNotDistinctFrom` (existing values preserved), for the downstream legs.
- A malformed `IS DISTINCT` with no `FROM` now **errors** instead of dropping the predicate.

## Before / after

`WHERE x IS DISTINCT FROM y` — before: `WhereClause → ColumnRef('x')` (3 trailing tokens, `DISTINCT FROM y` gone); after: `WhereClause → BinaryExpr('IS DISTINCT FROM') → [x, y]`.

## Tests

`test_parser_expr_hardening`: `IS DISTINCT FROM` / `IS NOT DISTINCT FROM` build the binary comparison over both operands; `IS DISTINCT` without `FROM` is rejected; `IS NULL` / `IS TRUE` regressions intact. Full suite **37/37 green**.

## Downstream

The analyzer will type `IS [NOT] DISTINCT FROM` as `Boolean`, never-NULL; the binder's `map_binary_op` will map the operator text to the new enum values and lower it. Those PRs bump their parser pin to this commit.

Part of the parser-layer robustness pass (CASE fixes are in #46; `IN`-without-parens and the set-operation drops follow).
