### PR TITLE
parser: enforce DepthGuard in DDL and stop trigger-body infinite loop

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -64,7 +64,8 @@ namespace {
 
 ast::ASTNode* Parser::parse_create_stmt() {
     // Dispatch to specific CREATE statement based on object type
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // Save state in case we need to reset
     const auto* start_token = current_token_;
@@ -277,7 +278,8 @@ ast::ASTNode* Parser::parse_create_view_impl() {
 // ========== End Three-Tier Architecture ==========
 
 ast::ASTNode* Parser::parse_drop_stmt() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // Consume DROP keyword
     advance();
@@ -329,7 +331,8 @@ ast::ASTNode* Parser::parse_drop_stmt() {
 }
 
 ast::ASTNode* Parser::parse_truncate_stmt() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // Consume TRUNCATE keyword
     advance();
@@ -369,7 +372,8 @@ ast::ASTNode* Parser::parse_alter_table_stmt() {
 
 // Helper function to parse data type
 ast::ASTNode* Parser::parse_data_type() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     auto* type_node = arena_.allocate<ast::ASTNode>();
     new (type_node) ast::ASTNode(ast::NodeType::DataTypeNode);
@@ -488,7 +492,8 @@ ast::ASTNode* Parser::parse_data_type() {
 
 // Parse column constraint (NOT NULL, PRIMARY KEY, etc.)
 ast::ASTNode* Parser::parse_column_constraint() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     ast::ASTNode* constraint = nullptr;
     
@@ -669,7 +674,8 @@ int Parser::parse_paren_identifier_list(ast::ASTNode* parent) {
 }
 
 ast::ASTNode* Parser::parse_column_definition() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     auto* column = arena_.allocate<ast::ASTNode>();
     new (column) ast::ASTNode(ast::NodeType::ColumnDefinition);
@@ -714,7 +720,8 @@ ast::ASTNode* Parser::parse_column_definition() {
 
 // Parse table constraint (multi-column constraints)
 ast::ASTNode* Parser::parse_table_constraint() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     ast::ASTNode* constraint = nullptr;
 
@@ -867,7 +874,8 @@ ast::ASTNode* Parser::parse_table_constraint() {
 
 // Improved CREATE TABLE implementation
 ast::ASTNode* Parser::parse_create_table_impl() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // We're at TABLE keyword
     advance();  // Skip TABLE
@@ -976,7 +984,8 @@ ast::ASTNode* Parser::parse_create_table_impl() {
 
 // Improved ALTER TABLE implementation
 ast::ASTNode* Parser::parse_alter_table_full() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // We're at ALTER keyword
     advance();  // Skip ALTER
@@ -1195,7 +1204,8 @@ ast::ASTNode* Parser::parse_alter_table_full() {
 
 // Improved CREATE INDEX implementation
 ast::ASTNode* Parser::parse_create_index_full() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // We might be at UNIQUE or INDEX
     bool is_unique = false;
@@ -1332,7 +1342,8 @@ ast::ASTNode* Parser::parse_create_index_full() {
 
 // Parse CREATE TRIGGER statement
 ast::ASTNode* Parser::parse_create_trigger() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // We're at CREATE keyword
     advance();  // Skip CREATE
@@ -1473,10 +1484,25 @@ ast::ASTNode* Parser::parse_create_trigger() {
                 last_stmt = stmt;
                 trigger_node->child_count++;
             }
-            
-            // Skip semicolons between statements
+
+            // Skip semicolons between statements.
+            bool progressed = false;
             if (current_token_ && current_token_->value == ";") {
                 advance();
+                progressed = true;
+            }
+
+            // Forward-progress guard: if this iteration neither parsed a
+            // statement nor consumed a separator, the current token is one
+            // parse_statement() cannot start a statement from (a stray token, or
+            // the recursion-depth guard tripping and returning nullptr). Without
+            // this, the loop re-calls parse_statement() on the same token
+            // forever -- an infinite loop e.g. on `... BEGIN @ END`, and the hang
+            // that deep nested-trigger input degrades into once the depth guard
+            // stops it from overflowing the stack. Stop the body here; the parser
+            // is lenient about the unconsumed remainder.
+            if (!stmt && !progressed) {
+                break;
             }
         }
         
@@ -1502,7 +1528,8 @@ ast::ASTNode* Parser::parse_create_trigger() {
 
 // Parse CREATE SCHEMA statement
 ast::ASTNode* Parser::parse_create_schema() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
     
     // We're at CREATE keyword
     advance();  // Skip CREATE

--- a/src/parser/parser_statements.cpp
+++ b/src/parser/parser_statements.cpp
@@ -12,7 +12,8 @@ namespace db25::parser {
 // ========== Transaction Control Statements ==========
 
 ast::ASTNode* Parser::parse_transaction_stmt() {
-    if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
+    DepthGuard guard(this);
+    if (!guard.is_valid()) return nullptr;
 
     if (const auto keyword_id = current_token_->keyword_id; keyword_id == db25::Keyword::BEGIN || keyword_id == db25::Keyword::START) {
         // BEGIN [TRANSACTION|WORK] [isolation_level]

--- a/tests/security/test_depth_guard.cpp
+++ b/tests/security/test_depth_guard.cpp
@@ -68,7 +68,82 @@ std::string generate_nested_expr(int depth) {
     return sql.str();
 }
 
+// Generate deeply nested CREATE TRIGGER with a single-statement body:
+// CREATE TRIGGER ... CREATE TRIGGER ... (x depth) SELECT 1. Each level recurses
+// parse_create_trigger -> parse_statement -> parse_create_stmt -> parse_create_trigger.
+std::string generate_nested_triggers_single(int depth) {
+    std::stringstream sql;
+    for (int i = 0; i < depth; ++i) {
+        sql << "CREATE TRIGGER x AFTER INSERT ON t ";
+    }
+    sql << "SELECT 1";
+    return sql.str();
+}
+
+// Same recursion, but through the BEGIN ... END trigger-body form.
+std::string generate_nested_triggers_block(int depth) {
+    std::stringstream sql;
+    for (int i = 0; i < depth; ++i) {
+        sql << "CREATE TRIGGER x AFTER INSERT ON t BEGIN ";
+    }
+    sql << "SELECT 1";
+    for (int i = 0; i < depth; ++i) {
+        sql << " END";
+    }
+    return sql.str();
+}
+
 }  // namespace
+
+// A shallow chain of nested triggers stays under the limit and must parse. This
+// also confirms the recursion is real (each CREATE TRIGGER body can itself be a
+// statement), i.e. the deep cases below exercise a genuine recursion vector.
+TEST(DepthGuard, ShallowNestedTriggersParse) {
+    Parser parser;
+    ASSERT_TRUE(parser.parse(generate_nested_triggers_single(3)).has_value());
+    ASSERT_TRUE(parser.parse(generate_nested_triggers_block(3)).has_value());
+}
+
+// Deeply nested CREATE TRIGGER (single-statement body) previously drove unbounded
+// native recursion and overflowed the stack: every DDL entry point wrote its
+// DepthGuard as an if-init-statement, so the guard object was destroyed at the
+// end of the `if` and depth never accumulated. It must now be rejected gracefully.
+TEST(DepthGuard, DeeplyNestedTriggersSingleRejected) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+    auto result = parser.parse(generate_nested_triggers_single(static_cast<int>(limit) * 3));
+    ASSERT_FALSE(result.has_value())
+        << "Deeply nested CREATE TRIGGER must be rejected by the DepthGuard";
+    EXPECT_EQ(result.error().message, kDepthError);
+}
+
+// Deeply nested CREATE TRIGGER through the BEGIN ... END body form. Besides the
+// same defeated-guard stack overflow, this path had a second hazard: the body
+// loop re-called parse_statement() on a token it could not consume without ever
+// advancing, so once the depth guard returned nullptr the crash degraded into an
+// infinite loop. It must terminate and reject gracefully.
+TEST(DepthGuard, DeeplyNestedTriggersBlockRejected) {
+    Parser parser;
+    const size_t limit = parser.config().max_depth;
+    auto result = parser.parse(generate_nested_triggers_block(static_cast<int>(limit) * 3));
+    ASSERT_FALSE(result.has_value())
+        << "Deeply nested BEGIN..END triggers must be rejected by the DepthGuard";
+    EXPECT_EQ(result.error().message, kDepthError);
+}
+
+// A stray, unparseable token inside a BEGIN ... END trigger body must not hang.
+// The body loop calls parse_statement(), which returns nullptr on '@'; without a
+// forward-progress guard the loop spins on the same token forever. Completion of
+// this test (it does not time out) is the assertion; the parser must also stay
+// usable afterwards.
+TEST(DepthGuard, GarbageInTriggerBodyTerminates) {
+    Parser parser;
+    (void)parser.parse("CREATE TRIGGER x AFTER INSERT ON t BEGIN @ END");
+    // Reusable after the (previously hanging) input.
+    auto ok = parser.parse("SELECT * FROM users WHERE id = 1");
+    ASSERT_TRUE(ok.has_value())
+        << "Parser must remain usable after a malformed trigger body";
+}
 
 // A modestly nested query stays well under the default limit and must parse.
 TEST(DepthGuard, ShallowNestedQueryParses) {


### PR DESCRIPTION
## Summary

Two related crash / DoS defects on nested `CREATE TRIGGER`, both in the DDL recursion path. Found during the bottom-up audit (the tokenizer layer came back clean; this is the parser layer).

### 1. Defeated `DepthGuard` → stack overflow

Every DDL entry point (12 sites in `parser_ddl.cpp`) and `parse_transaction_stmt` (`parser_statements.cpp`) wrote the recursion guard as an **if-init-statement**:

```cpp
if (const DepthGuard guard(this); !guard.is_valid()) return nullptr;
```

The guard object is destroyed at the end of the `if`, so depth is incremented then immediately decremented and `max_depth` is never enforced for the function body. Nested `CREATE TRIGGER` recurses `parse_create_trigger → parse_statement → parse_create_stmt → parse_create_trigger` with no participant holding depth → unbounded native recursion → **stack-overflow crash** (confirmed under ASan). Rewritten as a function-scope local, matching the correct form already used in the select/expression parsers:

```cpp
DepthGuard guard(this);
if (!guard.is_valid()) return nullptr;
```

### 2. No-forward-progress infinite loop

The `BEGIN … END` trigger-body loop called `parse_statement()` and, on `nullptr`, only advanced when the next token was `;`. On any token it cannot start a statement from — a stray token such as `@`, or the depth guard now returning `nullptr` — it re-called `parse_statement()` on the **same token forever**. Once fix (1) stops the stack overflow, deep `BEGIN..END` input degraded into this hang; it is also **independently triggerable** by `CREATE TRIGGER x AFTER INSERT ON t BEGIN @ END`. Added a forward-progress guard: if an iteration neither parsed a statement nor consumed a separator, `break` (the parser is lenient about the unconsumed remainder).

Both defects were reproduced under ASan/UBSan and now resolve to a graceful `"Maximum recursion depth exceeded"` (deep nesting) or clean termination (stray token) — never a crash or hang.

## Tests

`tests/security/test_depth_guard.cpp`:
- shallow nested triggers (both body forms) parse;
- deeply nested single-statement and `BEGIN..END` trigger chains are rejected with the depth error;
- a stray token in a trigger body terminates and leaves the parser reusable.

**Falsifiable:** reverting (1) restores the ASan stack-overflow; reverting (2) restores the infinite-loop hang. Full suite **37/37**; depth-guard suite (11 tests) clean under **ASan/UBSan**.
