### PR TITLE
parser: retain DECIMAL/NUMERIC scale (was truncated to 0)

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -7,6 +7,7 @@
 #include "db25/parser/parser.hpp"
 #include "db25/parser/tokenizer_adapter.hpp"
 
+#include <algorithm>  // std::min (clamp DECIMAL precision/scale to a byte)
 #include <charconv>
 
 namespace db25::parser {
@@ -436,19 +437,25 @@ ast::ASTNode* Parser::parse_data_type() {
             advance(); // consume (
             parenthesis_depth_++;
             
-            // Parse precision
+            // Store precision and scale packed into the 16-bit semantic_flags:
+            // precision in the low byte, scale in the high byte. `semantic_flags`
+            // is uint16_t, so the previous `scale << 16` shifted entirely out of
+            // the field and was truncated to 0 -- DECIMAL(10,2) silently recorded
+            // scale=0. A byte each covers all real DECIMAL/NUMERIC types (ANSI max
+            // precision 38, and scale <= precision); both are clamped to 255 so an
+            // out-of-range literal cannot spill into the other field.
             if (current_token_ && current_token_->type == tokenizer::TokenType::Number) {
-                type_node->semantic_flags = static_cast<uint16_t>(
-                    parse_uint_or(current_token_->value, 0)); // Store precision
+                const uint32_t precision = parse_uint_or(current_token_->value, 0);
+                type_node->semantic_flags = static_cast<uint16_t>(std::min<uint32_t>(precision, 0xFF));
                 advance();
 
                 // Parse scale if present
                 if (current_token_ && current_token_->value == ",") {
                     advance(); // consume comma
                     if (current_token_ && current_token_->type == tokenizer::TokenType::Number) {
-                        // Store scale in upper 16 bits
-                        uint32_t scale = parse_uint_or(current_token_->value, 0);
-                        type_node->semantic_flags |= (scale << 16);
+                        const uint32_t scale = parse_uint_or(current_token_->value, 0);
+                        type_node->semantic_flags |= static_cast<uint16_t>(
+                            std::min<uint32_t>(scale, 0xFF) << 8);  // high byte
                         advance();
                     }
                 }

--- a/tests/test_ddl_statements.cpp
+++ b/tests/test_ddl_statements.cpp
@@ -26,7 +26,40 @@ protected:
         }
         return result.value();
     }
+
+    // First node in the tree with the given DataType (pre-order).
+    static ASTNode* find_type(ASTNode* n, DataType dt) {
+        if (!n) return nullptr;
+        if (n->data_type == dt) return n;
+        for (auto* c = n->first_child; c; c = c->next_sibling) {
+            if (auto* h = find_type(c, dt)) return h;
+        }
+        return nullptr;
+    }
 };
+
+// DECIMAL/NUMERIC precision AND scale must both survive parsing. They are packed
+// into the 16-bit semantic_flags as precision (low byte) | scale (high byte).
+// Regression: scale was written as `scale << 16` into a uint16_t and truncated
+// to 0, so DECIMAL(10,2) silently recorded scale=0.
+TEST_F(DDLTest, DecimalPrecisionAndScaleRetained) {
+    auto* ast = parse("CREATE TABLE t (x DECIMAL(10,2))");
+    ASSERT_NE(ast, nullptr);
+    auto* type = find_type(ast, DataType::Decimal);
+    ASSERT_NE(type, nullptr) << "DECIMAL type node not found";
+    EXPECT_EQ(type->semantic_flags & 0xFF, 10u) << "precision (low byte)";
+    EXPECT_EQ((type->semantic_flags >> 8) & 0xFF, 2u) << "scale (high byte)";
+}
+
+// NUMERIC with precision only: scale defaults to 0, precision still retained.
+TEST_F(DDLTest, DecimalPrecisionOnly) {
+    auto* ast = parse("CREATE TABLE t (x NUMERIC(18))");
+    ASSERT_NE(ast, nullptr);
+    auto* type = find_type(ast, DataType::Decimal);
+    ASSERT_NE(type, nullptr);
+    EXPECT_EQ(type->semantic_flags & 0xFF, 18u);
+    EXPECT_EQ((type->semantic_flags >> 8) & 0xFF, 0u);
+}
 
 // ============================================================================
 // CREATE INDEX


### PR DESCRIPTION
## Summary

`type_node->semantic_flags` is `uint16_t`, but the scale of a `DECIMAL(p,s)` / `NUMERIC(p,s)` type was written as `scale << 16` — shifted entirely out of the 16-bit field and truncated to 0. `DECIMAL(10,2)` recorded precision=10 but **scale=0**, silently discarding parsed information. (No UB — the shift is on a `uint32_t` temporary — just lost metadata.)

Found in the bottom-up parser audit alongside the nested-`CREATE TRIGGER` crash (separate PR). Minor severity: nothing downstream currently reads the packed precision/scale (the analyzer derives the type from the type *name* and strips the `(...)`), so this is a "parser must not silently drop what it parsed" correctness fix rather than an observable wrong-result today.

## Change

Pack both values into `semantic_flags`: **precision in the low byte, scale in the high byte**. A byte each covers all real DECIMAL/NUMERIC types (ANSI max precision 38, and scale ≤ precision); both are clamped to 255 so an out-of-range literal cannot spill into the other field.

Decode is `precision = flags & 0xFF`, `scale = (flags >> 8) & 0xFF`.

## Tests

`tests/test_ddl_statements.cpp`:
- `DECIMAL(10,2)` → precision=10, scale=2;
- `NUMERIC(18)` → precision=18, scale=0.

**Falsifiable:** the scale assertion fails under the old `scale << 16`. Full suite **37/37**.

