### PR TITLE
parser: handle VALUES as a parenthesized/set-op query operand; reject non-query

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -500,6 +500,13 @@ ast::ASTNode* Parser::parse_parenthesized_query() {
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         current_token_->keyword_id == db25::Keyword::WITH) {
         inner = parse_with_statement();
+    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+               current_token_->keyword_id == db25::Keyword::VALUES) {
+        // `( VALUES (..), (..) )` is a query block too. Without this, VALUES fell
+        // to the SELECT path below and parse_select_stmt consumed the `VALUES`
+        // keyword as if it were `SELECT`, silently transposing the rows into a
+        // one-row select list.
+        inner = parse_values_stmt();
     } else if (current_token_ && current_token_->type == tokenizer::TokenType::Delimiter &&
                current_token_->value == "(") {
         // Nested parenthesized query expression: `((SELECT 1) UNION (SELECT 2))`.
@@ -507,10 +514,18 @@ ast::ASTNode* Parser::parse_parenthesized_query() {
         if (ast::ASTNode* nested = parse_parenthesized_query()) {
             inner = fold_set_operations(nested);
         }
-    } else {
+    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+               current_token_->keyword_id == db25::Keyword::SELECT) {
         // A leading SELECT parses fully here (set-op fold + trailing ORDER BY /
         // LIMIT) because in_setop_rhs_ is cleared above.
         inner = parse_select_stmt();
+    } else {
+        // Not a query block. parse_select_stmt() would blindly consume the first
+        // token as if it were SELECT (e.g. `(1 + 2)` -> `SELECT + 2`), a silent
+        // mis-parse; reject instead.
+        error("expected a query (SELECT, VALUES, WITH, or a parenthesized query) "
+              "after '('");
+        return nullptr;
     }
 
     in_setop_rhs_ = saved_rhs;
@@ -553,6 +568,14 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
             auto* branch = parse_select_stmt();
             in_setop_rhs_ = false;
             return branch;
+        }
+        // A bare VALUES arm: `SELECT 1 UNION VALUES (2)`. VALUES has no set-op
+        // tail of its own, so it is parsed as a complete operand. Without this
+        // the fold loop saw a non-`(`/SELECT operand, stopped, and silently
+        // dropped the operator and the whole VALUES arm.
+        if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+            (current_token_->keyword_id == db25::Keyword::VALUES)) {
+            return parse_values_stmt();
         }
         return nullptr;
     };

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -326,3 +326,49 @@ TEST_F(PrecedenceRegressionTest, LoneParenthesizedQueryUnwraps) {
     ASSERT_NE(root, nullptr);
     EXPECT_EQ(root->node_type, NodeType::SelectStmt);
 }
+
+// ---- Parenthesized VALUES / non-query operands -----------------------------
+// A parenthesized query block may be a VALUES list, not only a SELECT. Previously
+// parse_parenthesized_query fell through to parse_select_stmt, which consumed the
+// VALUES keyword as if it were SELECT and silently transposed the rows into a
+// one-row select list.
+
+// `(VALUES ...)` is a VALUES statement, identical to the unparenthesized form.
+TEST_F(PrecedenceRegressionTest, ParenthesizedValuesIsValues) {
+    auto* root = parse("(VALUES (2), (3))");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::ValuesStmt);
+    // Two rows survive (the mis-parse produced a single 2-column SELECT list).
+    ASTNode* rows = root->first_child;
+    ASSERT_NE(rows, nullptr);
+    EXPECT_EQ(rows->child_count, 2u);
+}
+
+// A VALUES arm of a set operation is kept, whether parenthesized or bare.
+TEST_F(PrecedenceRegressionTest, SetOpValuesOperandKept) {
+    {
+        auto* root = parse("(SELECT 1) UNION (VALUES (2), (3))");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+        auto* right = root->first_child ? root->first_child->next_sibling : nullptr;
+        ASSERT_NE(right, nullptr);
+        EXPECT_EQ(right->node_type, NodeType::ValuesStmt);
+    }
+    {
+        // Bare VALUES operand: previously the whole `UNION VALUES (2)` arm was
+        // silently dropped and the statement read as a lone SELECT.
+        auto* root = parse("SELECT 1 UNION VALUES (2)");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+        auto* right = root->first_child ? root->first_child->next_sibling : nullptr;
+        ASSERT_NE(right, nullptr);
+        EXPECT_EQ(right->node_type, NodeType::ValuesStmt);
+    }
+}
+
+// A leading `(` that does not begin a query block (e.g. a parenthesized scalar
+// expression) is rejected, not silently mis-parsed. `(1 + 2)` previously became
+// `SELECT + 2` (the `1` consumed as if it were the SELECT keyword).
+TEST_F(PrecedenceRegressionTest, ParenthesizedNonQueryRejected) {
+    EXPECT_EQ(parse("(1 + 2)"), nullptr);
+}


### PR DESCRIPTION
## Summary

Second-pass audit finding (regression scope of the earlier leading-parenthesized-query work). `parse_parenthesized_query` / `fold_set_operations` only recognized `SELECT`, `WITH`, and a nested `(` as the inner query; anything else fell through to `parse_select_stmt()`, which unconditionally advances past its first token assuming it is `SELECT`. This silently mis-parsed valid SQL:

| Input | Was (silently wrong) | Should be |
|---|---|---|
| `(VALUES (2), (3))` | `SELECT 2, 3` (VALUES dropped; 2 rows transposed into one 1-row/2-col select) | a 2-row `ValuesStmt` |
| `(SELECT 1) UNION (VALUES (2))` | UNION whose right arm is a mangled `SELECT 2` | UNION with a `ValuesStmt` arm |
| `SELECT 1 UNION VALUES (2)` | `SELECT 1` (the whole `UNION VALUES` arm dropped) | UNION with a `ValuesStmt` arm |
| `(1 + 2)` | `SELECT + 2` (the `1` eaten as if it were `SELECT`) | clean parse failure |

## Fix

- **`parse_parenthesized_query`**: dispatch a leading `VALUES` to `parse_values_stmt()`; require an explicit `SELECT` for the select path; and reject any other leading token (a parenthesized non-query such as `(1 + 2)`) with an error instead of the blind `parse_select_stmt()` mis-parse.
- **`parse_setop_operand`**: accept a bare `VALUES` arm (`… UNION VALUES (…)`), parsed as a complete operand (VALUES has no set-op tail of its own), so the fold no longer stops and drops the operator + arm.

`(VALUES …)` now yields the same `ValuesStmt` as the unparenthesized form, a VALUES set-op arm is preserved (parenthesized or bare), and a parenthesized scalar expression is rejected cleanly.

## Tests (`test_precedence_regression`)

Parenthesized VALUES is a `ValuesStmt` with both rows; a VALUES set-op arm (parenthesized and bare) is kept; a parenthesized non-query is rejected. Full suite **37/37**; the changed paths are clean under **ASan/UBSan**.

## Scope

`TABLE <name>` as a set-op operand remains unsupported (it isn't a statement type the parser recognizes anywhere) — a separate feature gap, not addressed here.
