### PR TITLE
parser: reject DISTINCT ON instead of fabricating an ON() call

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -334,6 +334,16 @@ ast::ASTNode* Parser::parse_select_stmt() {
         if (current_token_->keyword_id == db25::Keyword::DISTINCT) {
             select_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::Distinct);
             advance(); // consume DISTINCT
+            // `DISTINCT ON (expr, ...)` (PostgreSQL) is not supported. Reject it
+            // instead of falling through to the select-list parser, which read
+            // `ON (a)` as a function call `ON(a)` occupying the first output slot
+            // and consumed the intended first column as its alias - silently
+            // dropping a projected column.
+            if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+                current_token_->keyword_id == db25::Keyword::ON) {
+                error("DISTINCT ON is not supported");
+                return nullptr;
+            }
         } else if (current_token_->keyword_id == db25::Keyword::ALL) {
             select_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::All);
             advance(); // consume ALL

--- a/tests/test_parser_negative.cpp
+++ b/tests/test_parser_negative.cpp
@@ -90,3 +90,17 @@ TEST(ParserNegativeTest, DeleteMissingFrom) {
 TEST(ParserNegativeTest, GarbageInput) {
     expect_parse_error("GARBAGE tokens here");
 }
+
+// `DISTINCT ON (...)` (PostgreSQL) is unsupported and must be rejected, not
+// silently mis-parsed: previously `ON (a)` was read as a function call `ON(a)`
+// that took the first output slot and swallowed the intended first column `a`
+// as its alias, dropping a projected column.
+TEST(ParserNegativeTest, DistinctOnUnsupported) {
+    expect_parse_error("SELECT DISTINCT ON (a) a, b FROM t");
+}
+
+// Plain DISTINCT (no ON) is unaffected and still parses.
+TEST(ParserNegativeTest, PlainDistinctStillParses) {
+    Parser parser;
+    EXPECT_TRUE(parser.parse("SELECT DISTINCT a, b FROM t").has_value());
+}


### PR DESCRIPTION
## Summary

Second-pass audit finding F3 (dialect gap, silently-wrong-AST). `SELECT DISTINCT ON (a) a, b FROM t` was silently mis-parsed: after consuming `DISTINCT`, the select-list parser read `ON (a)` as a function call `ON(a)` occupying the first output slot, then took the intended first column `a` as that call's **alias** — dropping a projected column and turning the query into `SELECT DISTINCT ON(a) AS a, b`.

`DISTINCT ON` (a PostgreSQL extension) is not supported. Reject it cleanly right after `DISTINCT` (error, no AST) rather than producing the wrong tree. Plain `DISTINCT` (no `ON`) is unaffected.

Full `DISTINCT ON` *support* (distinct-on expression list + its analyzer/binder legs) is a separate feature, out of scope — this removes the silent mis-parse.

## Tests (`test_parser_negative`)

`DISTINCT ON (...)` is rejected; plain `DISTINCT a, b` still parses. Full suite **37/37**.
