### PR TITLE
parser: fold set-op keywords case-insensitively (mixed-case arms were dropped)

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -613,7 +613,10 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
     auto fold_intersects = [&](ast::ASTNode* left) -> ast::ASTNode* {
         while (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
             std::string_view keyword = current_token_->value;
-            if (!(keyword == "INTERSECT" || keyword == "intersect")) {
+            // Match on the case-insensitive keyword_id, not the case-preserved
+            // spelling: SQL keywords are case-insensitive, so `Intersect` must
+            // fold exactly like INTERSECT / intersect (else the arm is dropped).
+            if (current_token_->keyword_id != db25::Keyword::INTERSECT) {
                 break;  // not INTERSECT: hand back to the union level
             }
             advance(); // consume INTERSECT
@@ -639,10 +642,13 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
     while (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
         std::string_view keyword = current_token_->value;
         ast::NodeType set_op_type;
-        if (keyword == "UNION" || keyword == "union") {
+        // Case-insensitive keyword_id match (see fold_intersects): a mixed-case
+        // `Union` / `Except` is the same operator as its UPPER / lower spelling.
+        // (MINUS is not a set-op keyword in this tokenizer, so it never reaches
+        // this Keyword-typed loop; it was only ever handled here dead.)
+        if (current_token_->keyword_id == db25::Keyword::UNION) {
             set_op_type = ast::NodeType::UnionStmt;
-        } else if (keyword == "EXCEPT" || keyword == "except" ||
-                   keyword == "MINUS" || keyword == "minus") {
+        } else if (current_token_->keyword_id == db25::Keyword::EXCEPT) {
             set_op_type = ast::NodeType::ExceptStmt;
         } else {
             break;  // not a union-level operator (INTERSECT already folded): done

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -200,6 +200,40 @@ TEST_F(PrecedenceRegressionTest, UnionAllModifierSurvivesIntersectRegroup) {
     EXPECT_EQ(right->node_type, NodeType::IntersectStmt);
 }
 
+// SQL keywords are case-insensitive, so a MIXED-case set-op keyword must fold
+// exactly like its UPPER/lower spelling. Regression: the fold matched the
+// case-preserved token text against only "UNION"/"union", so `Union` fell
+// through, the loop stopped, and the right arm (and operator) were SILENTLY
+// dropped -- `SELECT 1 Union SELECT 2` parsed to a lone SELECT 1. Now the fold
+// matches on the case-insensitive keyword_id.
+TEST_F(PrecedenceRegressionTest, MixedCaseUnionFolds) {
+    auto* ast = parse("SELECT 1 Union SELECT 2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::UnionStmt);
+    EXPECT_EQ(ast->child_count, 2u);  // both arms kept, nothing dropped
+}
+
+// Mixed-case EXCEPT (any casing) folds like EXCEPT.
+TEST_F(PrecedenceRegressionTest, MixedCaseExceptFolds) {
+    auto* ast = parse("SELECT 1 ExCePt SELECT 2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::ExceptStmt);
+    EXPECT_EQ(ast->child_count, 2u);
+}
+
+// Mixed-case INTERSECT still binds tighter than UNION: `A UNION B Intersect C`
+// -> UNION(A, INTERSECT(B, C)). Proves the keyword_id switch preserved both the
+// fold and the precedence for a mixed-case inner keyword (regression: the
+// `Intersect` arm was dropped, leaving a plain 2-arm UNION).
+TEST_F(PrecedenceRegressionTest, MixedCaseIntersectBindsTighterThanUnion) {
+    auto* ast = parse("SELECT 1 UNION SELECT 2 Intersect SELECT 3");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::UnionStmt);
+    auto* right = ast->first_child ? ast->first_child->next_sibling : nullptr;
+    ASSERT_NE(right, nullptr);
+    EXPECT_EQ(right->node_type, NodeType::IntersectStmt);
+}
+
 // GROUP BY with a missing item must not crash (regression: the old code called
 // global delete on an arena-allocated node -> UB). The parser is lenient, so it
 // still returns a SelectStmt; the point is that it completes cleanly (and does


### PR DESCRIPTION
## Problem

`fold_set_operations` decided the set operator by comparing the **case-preserved** token text against only the UPPER and lower spellings:

```cpp
if (keyword == "UNION" || keyword == "union") { ... }
else if (keyword == "EXCEPT" || keyword == "except" || keyword == "MINUS" || keyword == "minus") { ... }
// and for INTERSECT: if (!(keyword == "INTERSECT" || keyword == "intersect")) break;
```

SQL keywords are case-insensitive, so a **mixed-case** spelling like `Union` / `Intersect` / `ExCePt` matched neither branch. The fold loop then `break`s — and the operator **plus the entire right operand are silently dropped**:

| Input | Before | After (correct) |
|-------|--------|-----------------|
| `SELECT 1 Union SELECT 2` | lone `SELECT 1` (right arm gone) | `UNION(SELECT 1, SELECT 2)` |
| `SELECT 1 UNION SELECT 2 Intersect SELECT 3` | `UNION(1, 2)` — INTERSECT arm gone, wrong shape | `UNION(1, INTERSECT(2, 3))` |
| `SELECT 1 ExCePt SELECT 2` | lone `SELECT 1` | `EXCEPT(SELECT 1, SELECT 2)` |

This is a **silently-wrong result**: a legal multi-arm set query is truncated to its first branch with no diagnostic. Uppercase and all-lowercase both worked; only mixed case failed. Found by the repeatable frontend-audit's regression sweep of the INTERSECT-precedence set-op fold.

## Fix

Match on the case-insensitive `current_token_->keyword_id` (the tokenizer already sets `Keyword::UNION` / `INTERSECT` / `EXCEPT` for **any** casing) instead of the case-preserved spelling. The original spelling is still copied into `primary_text`, so the node's displayed keyword keeps the user's casing.

`MINUS` is **not** a set-op keyword in this tokenizer (there is no `Keyword::MINUS`), so it is never a `Keyword`-typed token and never reached this `Keyword`-gated loop — the old `"MINUS"` string branch was dead code. Dropping it changes nothing (verified: `... users MINUS SELECT ...` still parses exactly as before, with `MINUS` consumed as a table alias).

## Tests

Adds three regression tests to `test_precedence_regression.cpp`:
- `MixedCaseUnionFolds` — `Union` keeps both arms
- `MixedCaseExceptFolds` — `ExCePt` folds as EXCEPT
- `MixedCaseIntersectBindsTighterThanUnion` — mixed-case inner `Intersect` preserves both the fold and the precedence

Full suite: **37/37 green**.
