### PR TITLE
parser: don't let a bare VALUES set-op arm swallow the whole query's ORDER BY/LIMIT

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -585,7 +585,14 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
         // dropped the operator and the whole VALUES arm.
         if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
             (current_token_->keyword_id == db25::Keyword::VALUES)) {
-            return parse_values_stmt();
+            // Mark the operand as a set-op RHS so parse_values_stmt does not eat a
+            // trailing ORDER BY / LIMIT that belongs to the whole set operation
+            // (mirrors the SELECT arm above). Without this the clause was nested
+            // under the VALUES arm instead of the combined node.
+            in_setop_rhs_ = true;
+            auto* branch = parse_values_stmt();
+            in_setop_rhs_ = false;
+            return branch;
         }
         return nullptr;
     };

--- a/src/parser/parser_statements.cpp
+++ b/src/parser/parser_statements.cpp
@@ -177,7 +177,17 @@ ast::ASTNode* Parser::parse_explain_stmt() {
 ast::ASTNode* Parser::parse_values_stmt() {
     DepthGuard guard(this);
     if (!guard.is_valid()) return nullptr;
-    
+
+    // If this VALUES is the right-hand operand of an enclosing set operation
+    // (`SELECT 1 UNION VALUES (2) ORDER BY 1`), it must NOT swallow a trailing
+    // ORDER BY / LIMIT: those bind to the WHOLE set operation and are parsed
+    // once, after folding (see fold_set_operations / attach_trailing_order_limit),
+    // exactly as the bare-SELECT arm handles it. Capture and clear the flag so
+    // any nested parse behaves normally; a parenthesized `(VALUES ...)` operand
+    // re-enters with the flag already cleared and so keeps its own ORDER BY.
+    const bool is_setop_rhs = in_setop_rhs_;
+    in_setop_rhs_ = false;
+
     auto* values_node = arena_.allocate<ast::ASTNode>();
     new (values_node) ast::ASTNode(ast::NodeType::ValuesStmt);
     values_node->node_id = next_node_id_++;
@@ -259,8 +269,9 @@ ast::ASTNode* Parser::parse_values_stmt() {
     values_node->first_child = values_clause;
     values_node->child_count = 1;
     
-    // Parse optional ORDER BY
-    if (current_token_ && current_token_->keyword_id == db25::Keyword::ORDER) {
+    // Parse optional ORDER BY (unless this VALUES is a set-op RHS operand, in
+    // which case a trailing ORDER BY belongs to the whole set operation).
+    if (!is_setop_rhs && current_token_ && current_token_->keyword_id == db25::Keyword::ORDER) {
         advance(); // consume ORDER
         if (current_token_ && current_token_->keyword_id == db25::Keyword::BY) {
             advance(); // consume BY
@@ -272,9 +283,9 @@ ast::ASTNode* Parser::parse_values_stmt() {
             }
         }
     }
-    
-    // Parse optional LIMIT
-    if (current_token_ && current_token_->keyword_id == db25::Keyword::LIMIT) {
+
+    // Parse optional LIMIT (same set-op RHS caveat as ORDER BY above).
+    if (!is_setop_rhs && current_token_ && current_token_->keyword_id == db25::Keyword::LIMIT) {
         advance(); // consume LIMIT
         auto* limit = parse_limit_clause();
         if (limit) {

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -366,6 +366,57 @@ TEST_F(PrecedenceRegressionTest, SetOpValuesOperandKept) {
     }
 }
 
+// A trailing ORDER BY / LIMIT after a BARE VALUES set-op arm binds to the WHOLE
+// set operation, not to the VALUES operand. Regression: parse_values_stmt eats a
+// trailing ORDER BY/LIMIT unconditionally, so `SELECT 1 UNION VALUES (2) ORDER BY 1`
+// nested the OrderByClause under the VALUES arm (UNION had only 2 children) --
+// unlike the SELECT arm and the parenthesized-VALUES arm, which both attach it to
+// the UNION. Now the bare-VALUES operand is parsed in setop-rhs mode and does not
+// swallow the clause.
+TEST_F(PrecedenceRegressionTest, SetOpBareValuesTrailingOrderByBindsToWhole) {
+    auto* root = parse("SELECT 1 UNION VALUES (2) ORDER BY 1");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+    // ORDER BY is a direct child of the UNION, not of the VALUES arm.
+    ASTNode* order_by = nullptr;
+    ASTNode* values = nullptr;
+    for (auto* c = root->first_child; c; c = c->next_sibling) {
+        if (c->node_type == NodeType::OrderByClause) order_by = c;
+        if (c->node_type == NodeType::ValuesStmt) values = c;
+    }
+    ASSERT_NE(order_by, nullptr) << "ORDER BY must attach to the UNION node";
+    ASSERT_NE(values, nullptr);
+    EXPECT_EQ(find(values, NodeType::OrderByClause), nullptr)
+        << "the VALUES arm must not own the trailing ORDER BY";
+}
+
+// Same for LIMIT after a bare VALUES set-op arm.
+TEST_F(PrecedenceRegressionTest, SetOpBareValuesTrailingLimitBindsToWhole) {
+    auto* root = parse("SELECT 1 UNION VALUES (2) LIMIT 5");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+    ASTNode* limit = nullptr;
+    ASTNode* values = nullptr;
+    for (auto* c = root->first_child; c; c = c->next_sibling) {
+        if (c->node_type == NodeType::LimitClause) limit = c;
+        if (c->node_type == NodeType::ValuesStmt) values = c;
+    }
+    ASSERT_NE(limit, nullptr) << "LIMIT must attach to the UNION node";
+    ASSERT_NE(values, nullptr);
+    EXPECT_EQ(find(values, NodeType::LimitClause), nullptr)
+        << "the VALUES arm must not own the trailing LIMIT";
+}
+
+// Control: a TOP-LEVEL VALUES (not a set-op operand) still keeps its own ORDER BY
+// -- the set-op-rhs suppression must not leak to the standalone form.
+TEST_F(PrecedenceRegressionTest, TopLevelValuesKeepsOwnOrderBy) {
+    auto* root = parse("VALUES (3), (1), (2) ORDER BY 1");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::ValuesStmt);
+    EXPECT_NE(find(root, NodeType::OrderByClause), nullptr)
+        << "a standalone VALUES must keep its own ORDER BY";
+}
+
 // A leading `(` that does not begin a query block (e.g. a parenthesized scalar
 // expression) is rejected, not silently mis-parsed. `(1 + 2)` previously became
 // `SELECT + 2` (the `1` consumed as if it were the SELECT keyword).


### PR DESCRIPTION
## Problem

`parse_values_stmt()` consumes a trailing `ORDER BY` / `LIMIT` **unconditionally**. When `VALUES` is the right-hand operand of a set operation, that clause belongs to the **whole** set operation — but the bare-VALUES arm ate it and nested the clause **under the VALUES arm**:

```
SELECT 1 UNION VALUES (2) ORDER BY 1
```

| Right operand form | ORDER BY attaches to | Correct? |
|--------------------|----------------------|----------|
| `... UNION SELECT 2 ORDER BY 1` | the UNION (3 children) | ✅ |
| `... UNION (VALUES (2)) ORDER BY 1` | the UNION (3 children) | ✅ |
| `... UNION VALUES (2) ORDER BY 1` | **the VALUES arm** (UNION has only 2 children) | ❌ |

So the *same* trailing clause produced three different tree shapes depending on the right operand. In Postgres an unparenthesized set-op arm cannot own an `ORDER BY` — it belongs to the union. Found by the repeatable frontend-audit's regression sweep of the VALUES set-op-operand commit.

## Fix

Mirror what the bare-**SELECT** arm already does via `in_setop_rhs_`:

- `parse_values_stmt()` captures and clears `in_setop_rhs_` at entry (so nested parses behave normally) and **skips** its trailing `ORDER BY` / `LIMIT` when the flag was set.
- The bare-VALUES branch of `parse_setop_operand` sets `in_setop_rhs_` before calling, exactly like the SELECT arm.

The trailing clause is then bound **once** to the combined node by `attach_trailing_order_limit`, matching the SELECT and parenthesized-VALUES arms.

**Unchanged behavior preserved:**
- A standalone top-level `VALUES (...) ORDER BY 1` (flag false) still keeps its own `ORDER BY` / `LIMIT`.
- A parenthesized `(VALUES ...)` operand still keeps its own (it re-enters with the flag cleared).

## Tests

Adds to `test_precedence_regression.cpp`:
- `SetOpBareValuesTrailingOrderByBindsToWhole` — ORDER BY on the UNION, not the VALUES arm
- `SetOpBareValuesTrailingLimitBindsToWhole` — same for LIMIT
- `TopLevelValuesKeepsOwnOrderBy` — control: standalone VALUES still owns its ORDER BY

Full suite: **37/37 green**.

