### PR TITLE
parser: fold a top-level bare VALUES as a set-op LEFT operand

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -383,7 +383,17 @@ ast::ASTNode* Parser::parse_statement() {
     } else if (keyword_id == db25::Keyword::EXPLAIN) {
         return parse_explain_stmt();
     } else if (keyword_id == db25::Keyword::VALUES) {
-        return parse_values_stmt();
+        // A top-level VALUES is a query primary and may be the LEFT operand of a
+        // set operation (`VALUES (1) UNION SELECT 2`), exactly like a leading
+        // SELECT or a leading `(`. Fold any set-op tail; without this the
+        // operator and the entire right arm were silently dropped, leaving a
+        // bare ValuesStmt for a legal set-op query. (A standalone VALUES has no
+        // set-op tail, so fold_set_operations returns it unchanged.)
+        ast::ASTNode* first = parse_values_stmt();
+        if (!first) {
+            return nullptr;
+        }
+        return fold_set_operations(first);
     } else if (keyword_id == db25::Keyword::SET) {
         return parse_set_stmt();
     } else if (current_token_ && (current_token_->value == "VACUUM" || current_token_->value == "vacuum")) {  // TODO: Add VACUUM to keywords

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -400,6 +400,65 @@ TEST_F(PrecedenceRegressionTest, SetOpValuesOperandKept) {
     }
 }
 
+// A bare top-level VALUES may be the LEFT operand of a set operation. Regression:
+// parse_statement dispatched a leading VALUES straight to parse_values_stmt with
+// NO set-op fold (unlike the SELECT and leading-'(' paths), so `VALUES (1) UNION
+// SELECT 2` silently dropped the operator and the entire right arm, leaving a
+// bare ValuesStmt. Now the top-level VALUES is folded like any other operand.
+TEST_F(PrecedenceRegressionTest, SetOpBareValuesLeftOperand) {
+    {
+        auto* root = parse("VALUES (1) UNION SELECT 2");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+        EXPECT_EQ(root->child_count, 2u);  // both arms kept
+        auto* left = root->first_child;
+        auto* right = left ? left->next_sibling : nullptr;
+        ASSERT_NE(left, nullptr);
+        ASSERT_NE(right, nullptr);
+        EXPECT_EQ(left->node_type, NodeType::ValuesStmt);   // VALUES on the left
+        EXPECT_EQ(right->node_type, NodeType::SelectStmt);  // SELECT on the right
+    }
+    {
+        auto* root = parse("VALUES (1) INTERSECT SELECT 2");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->node_type, NodeType::IntersectStmt);
+        EXPECT_EQ(root->child_count, 2u);
+    }
+    {
+        auto* root = parse("VALUES (1) EXCEPT SELECT 2");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->node_type, NodeType::ExceptStmt);
+        EXPECT_EQ(root->child_count, 2u);
+    }
+}
+
+// A trailing ORDER BY after a `VALUES ... UNION ...` binds to the whole set
+// operation; the left VALUES operand does not swallow it.
+TEST_F(PrecedenceRegressionTest, SetOpBareValuesLeftOperandTrailingOrderBy) {
+    auto* root = parse("VALUES (1) UNION SELECT 2 ORDER BY 1");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnionStmt);
+    ASTNode* order_by = nullptr;
+    ASTNode* values = nullptr;
+    for (auto* c = root->first_child; c; c = c->next_sibling) {
+        if (c->node_type == NodeType::OrderByClause) order_by = c;
+        if (c->node_type == NodeType::ValuesStmt) values = c;
+    }
+    ASSERT_NE(order_by, nullptr) << "ORDER BY must attach to the UNION node";
+    ASSERT_NE(values, nullptr);
+    EXPECT_EQ(find(values, NodeType::OrderByClause), nullptr)
+        << "the left VALUES operand must not own the trailing ORDER BY";
+}
+
+// Control: a standalone top-level VALUES with its own ORDER BY is unchanged (no
+// set-op tail, so the fold returns it as-is and it keeps its ORDER BY).
+TEST_F(PrecedenceRegressionTest, StandaloneValuesUnchangedByFold) {
+    auto* root = parse("VALUES (3), (1), (2) ORDER BY 1");
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::ValuesStmt);
+    EXPECT_NE(find(root, NodeType::OrderByClause), nullptr);
+}
+
 // A trailing ORDER BY / LIMIT after a BARE VALUES set-op arm binds to the WHOLE
 // set operation, not to the VALUES operand. Regression: parse_values_stmt eats a
 // trailing ORDER BY/LIMIT unconditionally, so `SELECT 1 UNION VALUES (2) ORDER BY 1`


### PR DESCRIPTION
## Problem

`parse_statement` dispatched a leading `VALUES` straight to `parse_values_stmt()` with **no set-operation fold** — unlike the leading-`SELECT` path (`parse_select_stmt → fold_set_operations`) and the leading-`(` path (`parse_parenthesized_query → fold_set_operations`). So a top-level bare `VALUES` that is the **LEFT** operand of a set operation silently dropped the operator and the entire right arm:

```
VALUES (1) UNION SELECT 2   →   bare ValuesStmt(1)   -- "UNION SELECT 2" discarded, no error
```

The symmetric forms already worked: `SELECT 1 UNION VALUES (2)` → `UnionStmt`, and `(VALUES (1)) UNION SELECT 2` → `UnionStmt`. Only the bare-LEFT top-level case was left behind. `VALUES` is a query primary and a legal set-op operand on either side (Postgres: `VALUES (1) UNION SELECT 2` is a 2-row UNION). Found by the repeatable frontend-audit's regression sweep of the VALUES set-op work.

## Fix

Route the top-level `VALUES` through `fold_set_operations`, exactly like the other two leading-operand paths:

| Input | Before | After |
|-------|--------|-------|
| `VALUES (1) UNION SELECT 2` | `ValuesStmt(1)` | `UNION(VALUES(1), SELECT 2)` |
| `VALUES (1) INTERSECT SELECT 2` | `ValuesStmt(1)` | `INTERSECT(…)` |
| `VALUES (1) UNION SELECT 2 ORDER BY 1` | `ValuesStmt(1)` | `UNION(…)` with ORDER BY on the union |
| `VALUES (3),(1) ORDER BY 1` (standalone) | unchanged | unchanged — keeps its own ORDER BY |

A standalone `VALUES` has no set-op tail, so `fold_set_operations` returns it unchanged (and it keeps its own trailing `ORDER BY`/`LIMIT`); a `VALUES … UNION …` binds a trailing `ORDER BY` to the whole set operation.

This completes the VALUES-as-set-op-operand work of #53 (VALUES on the RHS) and #56 (bare-VALUES RHS ORDER BY).

## Tests

Adds `SetOpBareValuesLeftOperand` (UNION/INTERSECT/EXCEPT), `SetOpBareValuesLeftOperandTrailingOrderBy`, and a `StandaloneValuesUnchangedByFold` control to `test_precedence_regression`. Full suite **37/37 green**.
