### PR TITLE
parser: route every query-block site through one parse_query_body() (VALUES parity)

### DIFF
--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -224,6 +224,18 @@ protected:
     // inner query node. Used for a parenthesized set-operation operand, including
     // a LEADING one at statement level: `(SELECT 1) UNION (SELECT 2)`.
     [[nodiscard]] ast::ASTNode* parse_parenthesized_query();
+    // Parse a query-expression body at the current position (a SELECT, a VALUES
+    // list, a WITH ... query, or a nested parenthesized query block) and fold any
+    // set-operation tail. Returns the query node, or null if the current token
+    // does not begin a query (the caller decides whether that is a syntax error;
+    // this never emits a diagnostic itself). THIS is the single dispatch every
+    // query-block site shares - statement body, parenthesized query, CTE body,
+    // derived table, expression subquery, CREATE ... AS - so VALUES handling and
+    // set-op folding are identical everywhere and no site can silently omit a form.
+    [[nodiscard]] ast::ASTNode* parse_query_body();
+    // Whether the current token begins a query block (SELECT / VALUES / WITH):
+    // distinguishes a subquery from a grouped expression in expression context.
+    [[nodiscard]] bool at_query_block_start() const;
     // Fold a set-operation tail (UNION/INTERSECT/EXCEPT/MINUS, two precedence
     // levels, left-associative) onto an already-parsed first operand, then bind a
     // trailing ORDER BY / LIMIT to the whole result. Returns the folded node (the

--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -262,14 +262,16 @@ ast::ASTNode* Parser::parse_create_view_impl() {
     // Expect AS keyword
     if (current_token_ && current_token_->keyword_id == db25::Keyword::AS) {
         advance();
-        
-        // Parse SELECT statement
-        if (current_token_ && current_token_->keyword_id == db25::Keyword::SELECT) {
-            create_node->first_child = parse_select_stmt();
-            if (create_node->first_child) {
-                create_node->first_child->parent = create_node;
-                create_node->child_count = 1;
-            }
+
+        // The view body is any query expression - SELECT, a set operation, WITH,
+        // or a VALUES list (`CREATE VIEW v AS VALUES (1),(2)` /
+        // `... AS VALUES (1) UNION SELECT 2`). Dispatch through the shared
+        // query-body parser; previously only a leading SELECT was accepted, so a
+        // VALUES body was silently dropped (the view had no query child).
+        create_node->first_child = parse_query_body();
+        if (create_node->first_child) {
+            create_node->first_child->parent = create_node;
+            create_node->child_count = 1;
         }
     }
     

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -202,17 +202,20 @@ ast::ASTNode* Parser::parse_primary_expression() {
         parenthesis_depth_++;  // Track opening parenthesis
         advance(); // consume '('
         
-        // Check if it's a SELECT subquery
-        if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-            (current_token_->keyword_id == db25::Keyword::SELECT)) {
+        // A parenthesized subquery in expression / IN / EXISTS context may be any
+        // query block that begins with a keyword: SELECT, VALUES, or WITH (a bare
+        // `(` here stays a grouped expression / row constructor, unchanged). A
+        // leading VALUES was previously mis-parsed as a `VALUES(...)` function
+        // call, and `(VALUES (1) UNION SELECT 2)` left the `UNION ...` unconsumed.
+        if (at_query_block_start()) {
             // It's a subquery
             auto* subquery_node = arena_.allocate<ast::ASTNode>();
             new (subquery_node) ast::ASTNode(ast::NodeType::Subquery);
             subquery_node->node_id = next_node_id_++;
-            
+
             push_context(ParseContext::SUBQUERY);
-            // Parse the SELECT statement
-            auto* select_stmt = parse_select_stmt();
+            // Parse the query body (SELECT / VALUES / WITH), folding any set-op tail.
+            auto* select_stmt = parse_query_body();
             pop_context();
             if (select_stmt) {
                 select_stmt->parent = subquery_node;
@@ -706,9 +709,16 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
 
                 // Look for opening paren
                 if (current_token_ && current_token_->value == "(") {
-                    // Peek ahead to see if it's a SELECT
+                    // Peek ahead: a query-block keyword (SELECT / VALUES / WITH)
+                    // after `(` means `IN (subquery)`; anything else is an
+                    // `IN (expr, expr, ...)` value list. A leading VALUES was
+                    // previously treated as a list and mis-parsed as a `VALUES(..)`
+                    // function call (and `IN (VALUES (1) UNION SELECT 2)` dropped
+                    // the set-op tail).
                     if (peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
-                        peek_token_->keyword_id == db25::Keyword::SELECT) {
+                        (peek_token_->keyword_id == db25::Keyword::SELECT ||
+                         peek_token_->keyword_id == db25::Keyword::VALUES ||
+                         peek_token_->keyword_id == db25::Keyword::WITH)) {
                         // It's a subquery - parse it as a primary expression
                         in_operand = parse_primary_expression();
                     } else {

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -191,27 +191,12 @@ ast::ASTNode* Parser::parse_with_statement() {
         
         // At this point, we should be inside the CTE query parentheses
         
-        // Parse the CTE query (could be SELECT or WITH for nested CTEs)
-        ast::ASTNode* cte_query = nullptr;
-#ifdef DEBUG_CTE
-        // std::cerr << "DEBUG: About to parse CTE query. Current token: ";
-        if (current_token_) {
-            std::cerr << current_token_->value << " type: " << static_cast<int>(current_token_->type);
-        }
-        std::cerr << std::endl;
-#endif
-        if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword) {
-            if (current_token_->keyword_id == db25::Keyword::SELECT) {
-#ifdef DEBUG_CTE
-                // std::cerr << "DEBUG: Parsing SELECT in CTE" << std::endl;
-#endif
-                cte_query = parse_select_stmt();
-                // parse_select_stmt might return a UNION/INTERSECT/EXCEPT node
-                // That's fine for CTEs, especially recursive ones
-            } else if (current_token_->keyword_id == db25::Keyword::WITH) {
-                cte_query = parse_with_statement();
-            }
-        }
+        // The CTE body is any query expression - SELECT, a set operation, a
+        // nested WITH, or a VALUES list (`WITH t AS (VALUES (1),(2))` /
+        // `WITH t AS (VALUES (1) UNION SELECT 2)`). Dispatch through the shared
+        // query-body parser so it matches every other query-block site; the
+        // enclosing `(` was already consumed above and the `)` is consumed below.
+        ast::ASTNode* cte_query = parse_query_body();
         
         if (cte_query) {
             cte_query->parent = cte_def;
@@ -497,45 +482,61 @@ void Parser::attach_trailing_order_limit(ast::ASTNode* target) {
 // query node. The inner block is a complete query (may itself be a set operation,
 // or another parenthesized block) and keeps its own ORDER BY / LIMIT. Guarded
 // against deep `((((...))))` nesting.
+bool Parser::at_query_block_start() const {
+    if (!current_token_ || current_token_->type != tokenizer::TokenType::Keyword) {
+        return false;
+    }
+    const auto k = current_token_->keyword_id;
+    return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
+           k == db25::Keyword::WITH;
+}
+
+ast::ASTNode* Parser::parse_query_body() {
+    if (!current_token_) {
+        return nullptr;
+    }
+    // A query body is a complete, self-contained block: clear the set-op-RHS flag
+    // so the body folds its own set-op tail / trailing ORDER BY / LIMIT (restored
+    // for the caller). Every branch folds any set-operation tail, so a VALUES or
+    // SELECT operand followed by `UNION ...` is never left unconsumed.
+    const bool saved_rhs = in_setop_rhs_;
+    in_setop_rhs_ = false;
+    ast::ASTNode* result = nullptr;
+    if (current_token_->type == tokenizer::TokenType::Keyword &&
+        current_token_->keyword_id == db25::Keyword::WITH) {
+        result = parse_with_statement();
+    } else if (current_token_->type == tokenizer::TokenType::Keyword &&
+               current_token_->keyword_id == db25::Keyword::VALUES) {
+        if (ast::ASTNode* v = parse_values_stmt()) {
+            result = fold_set_operations(v);
+        }
+    } else if (current_token_->type == tokenizer::TokenType::Delimiter &&
+               current_token_->value == "(") {
+        // A nested parenthesized query block: `((SELECT 1) UNION (SELECT 2))`.
+        if (ast::ASTNode* nested = parse_parenthesized_query()) {
+            result = fold_set_operations(nested);
+        }
+    } else if (current_token_->type == tokenizer::TokenType::Keyword &&
+               current_token_->keyword_id == db25::Keyword::SELECT) {
+        // parse_select_stmt folds its own set-op tail + trailing ORDER BY / LIMIT.
+        result = parse_select_stmt();
+    }
+    in_setop_rhs_ = saved_rhs;
+    return result;
+}
+
 ast::ASTNode* Parser::parse_parenthesized_query() {
     DepthGuard guard(this);
     if (!guard.is_valid()) return nullptr;
 
     parenthesis_depth_++;
     advance(); // consume '('
-    const bool saved_rhs = in_setop_rhs_;
-    in_setop_rhs_ = false;  // inside the parens it is a complete query block
 
-    ast::ASTNode* inner = nullptr;
-    if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-        current_token_->keyword_id == db25::Keyword::WITH) {
-        inner = parse_with_statement();
-    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-               current_token_->keyword_id == db25::Keyword::VALUES) {
-        // `( VALUES (..), (..) )` is a query block too. Without this, VALUES fell
-        // to the SELECT path below and parse_select_stmt consumed the `VALUES`
-        // keyword as if it were `SELECT`, silently transposing the rows into a
-        // one-row select list. VALUES may also be the LEFT operand of a set
-        // operation INSIDE the parens (`( VALUES (1) UNION SELECT 2 )`), so fold
-        // any set-op tail here - exactly as the SELECT and nested-paren branches
-        // do - rather than leaving the `UNION ...` unconsumed (which then failed
-        // the `)` check and dropped the whole query).
-        if (ast::ASTNode* v = parse_values_stmt()) {
-            inner = fold_set_operations(v);
-        }
-    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Delimiter &&
-               current_token_->value == "(") {
-        // Nested parenthesized query expression: `((SELECT 1) UNION (SELECT 2))`.
-        // Parse the nested operand, then fold any set-op tail inside these parens.
-        if (ast::ASTNode* nested = parse_parenthesized_query()) {
-            inner = fold_set_operations(nested);
-        }
-    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-               current_token_->keyword_id == db25::Keyword::SELECT) {
-        // A leading SELECT parses fully here (set-op fold + trailing ORDER BY /
-        // LIMIT) because in_setop_rhs_ is cleared above.
-        inner = parse_select_stmt();
-    } else {
+    // Every parenthesized query dispatches through the one shared query-body
+    // parser, so a `( VALUES ... )`, `( VALUES (1) UNION SELECT 2 )`, or nested
+    // block is handled identically to the statement / derived-table / CTE sites.
+    ast::ASTNode* inner = parse_query_body();
+    if (!inner) {
         // Not a query block. parse_select_stmt() would blindly consume the first
         // token as if it were SELECT (e.g. `(1 + 2)` -> `SELECT + 2`), a silent
         // mis-parse; reject instead.
@@ -544,7 +545,6 @@ ast::ASTNode* Parser::parse_parenthesized_query() {
         return nullptr;
     }
 
-    in_setop_rhs_ = saved_rhs;
     if (current_token_ && current_token_->value == ")") {
         if (parenthesis_depth_ > 0) parenthesis_depth_--;
         advance(); // consume ')'
@@ -1566,22 +1566,12 @@ ast::ASTNode* Parser::parse_table_reference() {
             subquery_node->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::IsSubquery);
 
             push_context(ParseContext::SUBQUERY);
-            // The derived-table body is a SELECT, a WITH ... SELECT, or a VALUES
-            // list ( "(VALUES (1, 2), (3, 4)) AS t (a, b)" ). Dispatch on the
-            // leading keyword; without the VALUES arm the "(" matched neither a
-            // derived table nor a join group, so the whole FROM item was dropped.
-            ast::ASTNode* inner = nullptr;
-            if (current_token_ &&
-                current_token_->type == tokenizer::TokenType::Keyword &&
-                current_token_->keyword_id == db25::Keyword::WITH) {
-                inner = parse_with_statement();
-            } else if (current_token_ &&
-                       current_token_->type == tokenizer::TokenType::Keyword &&
-                       current_token_->keyword_id == db25::Keyword::VALUES) {
-                inner = parse_values_stmt();
-            } else {
-                inner = parse_select_stmt();
-            }
+            // The derived-table body is any query expression: a SELECT, a set
+            // operation, a WITH ... query, or a VALUES list - including a VALUES
+            // set operation (`(VALUES (1) UNION SELECT 2) t`). Dispatch through
+            // the shared query-body parser so the set-op tail is folded (a bare
+            // parse_values_stmt left `UNION ...` unconsumed and dropped the item).
+            ast::ASTNode* inner = parse_query_body();
             pop_context();
             if (inner) {
                 inner->parent = subquery_node;

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -615,3 +615,56 @@ TEST_F(PrecedenceRegressionTest, SetOpKeywordCasingMatrix) {
         }
     }
 }
+
+// ---------------------------------------------------------------------------
+// GUARDRAIL MATRIX: VALUES as a query BODY in every query-block context. VALUES
+// is a query primary, so it must parse anywhere a SELECT query body can - a FROM
+// derived table, a CTE body, a scalar / IN / EXISTS subquery, and CREATE VIEW AS
+// - both bare and as a set-operation. These sites historically each had their
+// own query-body dispatch and several accepted only SELECT, silently dropping or
+// MIS-PARSING a VALUES body (e.g. `SELECT (VALUES (1))` -> a `VALUES(1)` function
+// call; `x IN (VALUES (1),(2))` -> a 2-item value list). All sites now route
+// through the shared parse_query_body(); this table pins every context so a
+// future site cannot regress to a SELECT-only dispatch.
+// ---------------------------------------------------------------------------
+namespace {
+bool subtree_has(const ASTNode* n, NodeType t) {
+    if (!n) return false;
+    if (n->node_type == t) return true;
+    for (const ASTNode* c = n->first_child; c; c = c->next_sibling)
+        if (subtree_has(c, t)) return true;
+    return false;
+}
+}  // namespace
+
+TEST_F(PrecedenceRegressionTest, ValuesQueryBodyEveryContextMatrix) {
+    // Each case: the SQL, and the node type its query body must contain. The
+    // *_setop variant must fold to a UnionStmt (not drop the arm).
+    struct Case { const char* sql; NodeType must_contain; };
+    const Case cases[] = {
+        // FROM derived table
+        {"SELECT * FROM (VALUES (1),(2)) t",                         NodeType::ValuesStmt},
+        {"SELECT * FROM (VALUES (1) UNION SELECT 2) t",             NodeType::UnionStmt},
+        // CTE body (even the bare form was rejected before)
+        {"WITH t AS (VALUES (1),(2)) SELECT * FROM t",              NodeType::ValuesStmt},
+        {"WITH t AS (VALUES (1) UNION SELECT 2) SELECT * FROM t",   NodeType::UnionStmt},
+        // scalar subquery in the SELECT list
+        {"SELECT (VALUES (1))",                                     NodeType::ValuesStmt},
+        {"SELECT (VALUES (1) UNION SELECT 2)",                      NodeType::UnionStmt},
+        // IN subquery (was mis-parsed as a value list)
+        {"SELECT * FROM t WHERE x IN (VALUES (1),(2))",             NodeType::ValuesStmt},
+        {"SELECT * FROM t WHERE x IN (VALUES (1) UNION SELECT 2)",  NodeType::UnionStmt},
+        // EXISTS subquery
+        {"SELECT * FROM t WHERE EXISTS (VALUES (1))",               NodeType::ValuesStmt},
+        // CREATE VIEW AS (bare form was silently dropped)
+        {"CREATE VIEW v AS VALUES (1),(2)",                        NodeType::ValuesStmt},
+        {"CREATE VIEW v AS VALUES (1) UNION SELECT 2",             NodeType::UnionStmt},
+    };
+    for (const Case& c : cases) {
+        ASTNode* root = parse(c.sql);
+        ASSERT_NE(root, nullptr) << "dropped/failed to parse: " << c.sql;
+        EXPECT_TRUE(subtree_has(root, c.must_contain))
+            << c.sql << " -> query body missing/mis-parsed (expected node "
+            << static_cast<int>(c.must_contain) << ")";
+    }
+}


### PR DESCRIPTION
## Root cause

The fifth audit pass surfaced three "VALUES-as-query-body fails" findings — but they were symptoms of a **structural** problem: the parser had ~6 *separate, ad-hoc* "parse a query body" dispatchers, and several accepted only `SELECT`. So a `VALUES` body was silently **dropped** or **mis-parsed** depending on context. Enumerating VALUES in *every* query-block context found the complete set:

| Context | Before |
|---------|--------|
| `SELECT * FROM (VALUES (1) UNION SELECT 2) t` | "Unclosed parenthesis" (dropped) |
| `WITH t AS (VALUES (1),(2)) SELECT * FROM t` | "Failed to parse" — **even the bare form** |
| `SELECT (VALUES (1))` | parsed as a `VALUES(1)` **function call** |
| `x IN (VALUES (1),(2))` | parsed as a 2-item **value list** |
| `CREATE VIEW v AS VALUES (1),(2)` | view body **silently dropped** |

This is exactly the "fix one cell, miss the neighbors" pattern — the neighborhood was *"VALUES anywhere a query body is parsed,"* and prior fixes only covered 2 of ~6 sites.

## Fix

Introduce one `Parser::parse_query_body()` that dispatches `SELECT` / `VALUES` / `WITH` / nested-`(` and folds any set-operation tail, and **route every query-block site through it**:
- `parse_parenthesized_query` (its dispatch *is* now this helper)
- CTE body (`parse_with_statement`)
- derived table in FROM
- scalar / IN / EXISTS subquery (`parse_primary_expression`; IN's own peek now recognizes `VALUES`/`WITH`, not just `SELECT`)
- `CREATE VIEW … AS`

`at_query_block_start()` distinguishes a subquery from a grouped expression. Because all sites share **one** dispatch, no site can silently omit VALUES or a set-op fold again — VALUES now parses wherever a SELECT query body parses, as a proper `Subquery`/`ValuesStmt` with folding.

**Out of scope (consistent, not a VALUES divergence):** `CREATE TABLE AS` drops *both* a SELECT and a VALUES body (CTAS query bodies are unimplemented); INSERT keeps its own internal VALUES-rows representation.

## Guardrail

`ValuesQueryBodyEveryContextMatrix` pins VALUES (bare + set-op) in every context (FROM / CTE / scalar / IN / EXISTS / CREATE VIEW AS), each asserting the body contains the right node — not NULL, not a mis-parse.

Full suite **37/37 green**; ASan/UBSan clean on the suite and a query-body fuzz.
