### PR TITLE
parser: recognize a leading-'(' query body at the FROM / scalar / IN / EXISTS gates

### DIFF
--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -233,9 +233,17 @@ protected:
     // derived table, expression subquery, CREATE ... AS - so VALUES handling and
     // set-op folding are identical everywhere and no site can silently omit a form.
     [[nodiscard]] ast::ASTNode* parse_query_body();
-    // Whether the current token begins a query block (SELECT / VALUES / WITH):
-    // distinguishes a subquery from a grouped expression in expression context.
+    // Whether the current token begins a query block: a SELECT / VALUES / WITH
+    // keyword, OR a '(' that (after any number of nested '(') introduces one of
+    // those - so `((SELECT 1) UNION (SELECT 2))` is recognized as a subquery, not
+    // a grouped expression. Distinguishes a subquery from a grouped expression in
+    // expression context and a derived table from a join group in FROM.
     [[nodiscard]] bool at_query_block_start() const;
+    // Starting at token index `from`, skip consecutive '(' and report whether the
+    // first non-'(' token begins a query (SELECT / VALUES / WITH). Lets the FROM /
+    // scalar / IN gates recognize a parenthesized query body that starts with '('
+    // (a set operation over parenthesized branches) rather than a keyword.
+    [[nodiscard]] bool paren_group_starts_query(std::size_t from) const;
     // Fold a set-operation tail (UNION/INTERSECT/EXCEPT/MINUS, two precedence
     // levels, left-associative) onto an already-parsed first operand, then bind a
     // trailing ORDER BY / LIMIT to the whole result. Returns the folded node (the

--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -709,16 +709,15 @@ ast::ASTNode* Parser::parse_expression(int min_precedence) {
 
                 // Look for opening paren
                 if (current_token_ && current_token_->value == "(") {
-                    // Peek ahead: a query-block keyword (SELECT / VALUES / WITH)
-                    // after `(` means `IN (subquery)`; anything else is an
-                    // `IN (expr, expr, ...)` value list. A leading VALUES was
+                    // A query body after `(` means `IN (subquery)`; anything else
+                    // is an `IN (expr, expr, ...)` value list. The body starts with
+                    // a SELECT / VALUES / WITH keyword OR a nested `(` that
+                    // introduces one (`IN ((SELECT 1) UNION (SELECT 2))`), scanned
+                    // from one token past the current `(`. A leading VALUES was
                     // previously treated as a list and mis-parsed as a `VALUES(..)`
-                    // function call (and `IN (VALUES (1) UNION SELECT 2)` dropped
-                    // the set-op tail).
-                    if (peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
-                        (peek_token_->keyword_id == db25::Keyword::SELECT ||
-                         peek_token_->keyword_id == db25::Keyword::VALUES ||
-                         peek_token_->keyword_id == db25::Keyword::WITH)) {
+                    // function call; a leading `(` dropped the set-op tail.
+                    if (tokenizer_ != nullptr &&
+                        paren_group_starts_query(tokenizer_->position() + 1)) {
                         // It's a subquery - parse it as a primary expression
                         in_operand = parse_primary_expression();
                     } else {

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -482,13 +482,43 @@ void Parser::attach_trailing_order_limit(ast::ASTNode* target) {
 // query node. The inner block is a complete query (may itself be a set operation,
 // or another parenthesized block) and keeps its own ORDER BY / LIMIT. Guarded
 // against deep `((((...))))` nesting.
-bool Parser::at_query_block_start() const {
-    if (!current_token_ || current_token_->type != tokenizer::TokenType::Keyword) {
+bool Parser::paren_group_starts_query(std::size_t from) const {
+    if (tokenizer_ == nullptr) {
         return false;
     }
-    const auto k = current_token_->keyword_id;
+    const auto& tokens = tokenizer_->get_tokens();
+    std::size_t i = from;
+    // A query body may be wrapped in extra parentheses: `((SELECT 1) UNION ...)`.
+    while (i < tokens.size() &&
+           tokens[i].type == tokenizer::TokenType::Delimiter &&
+           tokens[i].value == "(") {
+        ++i;
+    }
+    if (i >= tokens.size() || tokens[i].type != tokenizer::TokenType::Keyword) {
+        return false;
+    }
+    const auto k = tokens[i].keyword_id;
     return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
            k == db25::Keyword::WITH;
+}
+
+bool Parser::at_query_block_start() const {
+    if (!current_token_) {
+        return false;
+    }
+    if (current_token_->type == tokenizer::TokenType::Keyword) {
+        const auto k = current_token_->keyword_id;
+        return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
+               k == db25::Keyword::WITH;
+    }
+    // A leading '(' that (past any nested parens) begins a query is a query block
+    // too: `((SELECT 1) UNION (SELECT 2))`. parse_query_body's '(' branch then
+    // parses it via parse_parenthesized_query and folds the set-op tail.
+    if (current_token_->type == tokenizer::TokenType::Delimiter &&
+        current_token_->value == "(" && tokenizer_ != nullptr) {
+        return paren_group_starts_query(tokenizer_->position());
+    }
+    return false;
 }
 
 ast::ASTNode* Parser::parse_query_body() {
@@ -1543,11 +1573,14 @@ ast::ASTNode* Parser::parse_table_reference() {
     // ( a JOIN b ON a.id = b.id ). Disambiguate on the following token.
     if (current_token_->type == tokenizer::TokenType::Delimiter &&
         current_token_->value == "(") {
+        // A derived table's body is a query: it starts with a SELECT / VALUES /
+        // WITH keyword, OR with a '(' that (past any nested parens) introduces
+        // one - `((SELECT 1) UNION (SELECT 2)) t`. Scan past the outer '(' (at
+        // position()) starting one token later. A parenthesized join group, by
+        // contrast, begins with an identifier or a '(' that wraps a table ref.
         const bool is_derived_table =
-            peek_token_ && peek_token_->type == tokenizer::TokenType::Keyword &&
-            (peek_token_->keyword_id == db25::Keyword::SELECT ||
-             peek_token_->keyword_id == db25::Keyword::WITH ||
-             peek_token_->keyword_id == db25::Keyword::VALUES);
+            tokenizer_ != nullptr &&
+            paren_group_starts_query(tokenizer_->position() + 1);
         // A parenthesized join group begins with something that itself begins a
         // table reference: an identifier (table name) or a nested '('.
         const bool is_join_group =

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -668,3 +668,46 @@ TEST_F(PrecedenceRegressionTest, ValuesQueryBodyEveryContextMatrix) {
             << static_cast<int>(c.must_contain) << ")";
     }
 }
+
+// GUARDRAIL: a parenthesized query body that begins with '(' (a set operation
+// over parenthesized branches, `((SELECT 1) UNION (SELECT 2))`) is a valid query
+// / subquery wherever a keyword-led one is. The query-body DISPATCH was unified
+// earlier, but the ENTRY GATES that decide whether to call it (the FROM derived-
+// table vs join-group split, the scalar-subquery test, the IN peek) recognized
+// only a leading KEYWORD, so a leading '(' was rejected in FROM / scalar / IN /
+// EXISTS while it worked at statement / CTE / CREATE VIEW. This pins every
+// context so a leading-'(' query body cannot regress at any gate.
+TEST_F(PrecedenceRegressionTest, ParenLedQueryBodyEveryContextMatrix) {
+    const char* queries[] = {
+        "((SELECT 1) UNION (SELECT 2)) LIMIT 1",                       // statement
+        "WITH t AS ((SELECT 1) UNION (SELECT 2)) SELECT * FROM t",     // CTE body
+        "CREATE VIEW v AS (SELECT 1) UNION (SELECT 2)",               // view (control)
+        "SELECT * FROM ((SELECT 1) UNION (SELECT 2)) t",              // FROM derived
+        "SELECT ((SELECT 1) UNION (SELECT 2)) FROM z",                // scalar subquery
+        "SELECT * FROM z WHERE x IN ((SELECT 1) UNION (SELECT 2))",   // IN subquery
+        "SELECT * FROM z WHERE EXISTS ((SELECT 1) UNION (SELECT 2))", // EXISTS subquery
+    };
+    for (const char* sql : queries) {
+        ASTNode* root = parse(sql);
+        ASSERT_NE(root, nullptr) << "rejected a legal parenthesized query body: " << sql;
+        EXPECT_NE(find(root, NodeType::UnionStmt), nullptr)
+            << sql << " -> the set-op body was dropped / mis-parsed (no UnionStmt)";
+    }
+    // A parenthesized FROM JOIN GROUP must still NOT be taken as a derived table.
+    {
+        ASTNode* root = parse("SELECT * FROM (a JOIN b ON a.id = b.id)");
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(find(root, NodeType::Subquery), nullptr)
+            << "a FROM join group must not be classified as a derived-table subquery";
+    }
+    // The double-paren derived table retains its column-alias list `(x)` (was
+    // silently dropped when it took the spurious join-group path).
+    {
+        ASTNode* root = parse("SELECT * FROM ((SELECT 1)) t(x)");
+        ASSERT_NE(root, nullptr);
+        EXPECT_NE(find(root, NodeType::Subquery), nullptr) << "((SELECT 1)) t(x) is a derived table";
+        // The `(x)` alias list is captured as a ColumnList somewhere in the tree.
+        EXPECT_NE(find(root, NodeType::ColumnList), nullptr)
+            << "the (x) column-alias list must be retained";
+    }
+}


### PR DESCRIPTION
## Root cause (a third instance of the same class)

PR #59 unified the query-body **dispatch** (`parse_query_body` handles a leading `(`), but the **entry gates** that decide whether to call it were left recognizing only a leading **keyword**. So a parenthesized set operation used as a query body — `((SELECT 1) UNION (SELECT 2))` — was accepted at the statement / CTE / CREATE VIEW sites but **rejected** everywhere a subquery is gated by lookahead:

```
SELECT * FROM ((SELECT 1) UNION (SELECT 2)) t             -> "Unclosed parenthesis"
SELECT ((SELECT 1) UNION (SELECT 2)) FROM z               -> "Unclosed parenthesis"
SELECT * FROM z WHERE x IN ((SELECT 1) UNION (SELECT 2))  -> "Unclosed parenthesis"
SELECT * FROM z WHERE EXISTS ((SELECT 1) UNION (SELECT 2))-> "Unclosed parenthesis"
```

Three gates were keyword-only: the FROM derived-table vs join-group split (a `(` whose next token is `(` was classified as a join group), `at_query_block_start()`, and the IN peek. A leading `(` never reached `parse_query_body`.

## Fix

Add `paren_group_starts_query(from)`: scan the token stream from `from` past any number of nested `(` and report whether the first non-`(` token begins a query (`SELECT`/`VALUES`/`WITH`). Route all three gates through it (and `at_query_block_start` now returns true for such a `(`), so a leading-`(` query body is recognized **everywhere** a keyword-led one is.

A FROM join group `(a JOIN b)` and a grouped expression `(1+2)` are unaffected — their first non-paren token isn't a query keyword.

**Side-effect fix:** the double-paren derived table `((SELECT 1)) t(x)` now takes the derived-table path and **retains its `(x)` column-alias list** (the spurious join-group path previously discarded it); its AST is now identical to `(SELECT 1) t(x)`.

## Guardrail

`ParenLedQueryBodyEveryContextMatrix` pins the parenthesized set-op body in every context (statement/CTE/VIEW/FROM/scalar/IN/EXISTS), a join-group negative control, and column-alias retention. Full suite **37/37 green** under `-fsanitize=address,undefined -fno-sanitize-recover=all`.
