### PR TITLE
parser: a parenthesized subquery left operand is a scalar expr, not a query body

### DIFF
--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -239,11 +239,22 @@ protected:
     // a grouped expression. Distinguishes a subquery from a grouped expression in
     // expression context and a derived table from a join group in FROM.
     [[nodiscard]] bool at_query_block_start() const;
-    // Starting at token index `from`, skip consecutive '(' and report whether the
-    // first non-'(' token begins a query (SELECT / VALUES / WITH). Lets the FROM /
-    // scalar / IN gates recognize a parenthesized query body that starts with '('
-    // (a set operation over parenthesized branches) rather than a keyword.
+    // Report whether the parenthesized group whose content begins at token index
+    // `from` is a query body: a query expression (SELECT / VALUES / WITH, possibly
+    // parenthesized and/or joined by set operations) that fills the group exactly.
+    // Distinguishes a parenthesized query body - `(SELECT 1)`, `((SELECT 1))`,
+    // `((SELECT 1) UNION (SELECT 2))` - from a grouped scalar expression whose left
+    // operand merely happens to be a parenthesized subquery, `((SELECT 1) + 2)`,
+    // and from a value list / join group. Used by the FROM / scalar / IN gates.
     [[nodiscard]] bool paren_group_starts_query(std::size_t from) const;
+    // Return the token index one past a maximal query expression starting at
+    // `from`, or kNoQueryExpr if `from` does not begin one. A query expression is a
+    // query primary (SELECT / VALUES / WITH, or a parenthesized query expression
+    // that fills its parens exactly) followed by an optional left-associative
+    // set-operation tail. `depth` bounds pathological `(((...)))` nesting.
+    static constexpr std::size_t kNoQueryExpr = static_cast<std::size_t>(-1);
+    [[nodiscard]] std::size_t scan_query_expression(std::size_t from,
+                                                    std::size_t depth) const;
     // Fold a set-operation tail (UNION/INTERSECT/EXCEPT/MINUS, two precedence
     // levels, left-associative) onto an already-parsed first operand, then bind a
     // trailing ORDER BY / LIMIT to the whole result. Returns the folded node (the

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -482,24 +482,153 @@ void Parser::attach_trailing_order_limit(ast::ASTNode* target) {
 // query node. The inner block is a complete query (may itself be a set operation,
 // or another parenthesized block) and keeps its own ORDER BY / LIMIT. Guarded
 // against deep `((((...))))` nesting.
+std::size_t Parser::scan_query_expression(std::size_t from,
+                                          std::size_t depth) const {
+    // Guard `(((...)))` from recursing this predicate to a stack overflow; beyond
+    // any realistic nesting we conservatively report "not a query expression" and
+    // let the normal recursive-descent DepthGuard produce a graceful error.
+    constexpr std::size_t kMaxDepth = 256;
+    if (tokenizer_ == nullptr || depth > kMaxDepth) {
+        return kNoQueryExpr;
+    }
+    const auto& tokens = tokenizer_->get_tokens();
+    const std::size_t n = tokens.size();
+    if (from >= n) {
+        return kNoQueryExpr;
+    }
+    const auto is_setop = [&](std::size_t j) {
+        return j < n && tokens[j].type == tokenizer::TokenType::Keyword &&
+               (tokens[j].keyword_id == db25::Keyword::UNION ||
+                tokens[j].keyword_id == db25::Keyword::INTERSECT ||
+                tokens[j].keyword_id == db25::Keyword::EXCEPT);
+    };
+    const auto is_open = [&](std::size_t j) {
+        return tokens[j].type == tokenizer::TokenType::Delimiter &&
+               tokens[j].value == "(";
+    };
+    const auto is_close = [&](std::size_t j) {
+        return tokens[j].type == tokenizer::TokenType::Delimiter &&
+               tokens[j].value == ")";
+    };
+
+    std::size_t j;
+    const auto& head = tokens[from];
+    if (head.type == tokenizer::TokenType::Keyword &&
+        (head.keyword_id == db25::Keyword::SELECT ||
+         head.keyword_id == db25::Keyword::VALUES ||
+         head.keyword_id == db25::Keyword::WITH)) {
+        // Keyword-rooted primary: scan its body, which absorbs any operators /
+        // clauses, until - at this parenthesis level - we reach a set-operation
+        // keyword (the tail, folded below) or the enclosing ')' (or end of input).
+        int pd = 0;
+        j = from;
+        while (j < n) {
+            if (is_open(j)) {
+                ++pd;
+            } else if (is_close(j)) {
+                if (pd == 0) {
+                    break;  // the group's closing ')'
+                }
+                --pd;
+            } else if (pd == 0 && is_setop(j)) {
+                break;  // set-operation tail at this level
+            }
+            ++j;
+        }
+    } else if (is_open(from)) {
+        // Parenthesized primary: it is a query primary only if its content is
+        // *itself* wholly a query expression - `(SELECT 1)`, `((SELECT 1) UNION
+        // ...)` - not a scalar expression that opens with a subquery.
+        //
+        // Cheap pre-check first: skip the run of leading '(' and require the
+        // innermost token to be a query keyword. A deeply nested join group,
+        // `((((t ...))))`, or a value list bails here in O(leading-parens) - WITHOUT
+        // the O(n) balanced scan below - so the FROM classifier stays linear per
+        // level instead of O(depth^2) over a `FROM ((((...))))` stress input.
+        std::size_t inner = from;
+        while (inner < n && is_open(inner)) {
+            ++inner;
+        }
+        if (inner >= n || tokens[inner].type != tokenizer::TokenType::Keyword) {
+            return kNoQueryExpr;
+        }
+        const auto kw = tokens[inner].keyword_id;
+        if (kw != db25::Keyword::SELECT && kw != db25::Keyword::VALUES &&
+            kw != db25::Keyword::WITH) {
+            return kNoQueryExpr;
+        }
+        // The innermost token is a query keyword: only now pay for the balanced
+        // scan that verifies the content fills the parens exactly as a query.
+        int pd = 0;
+        std::size_t close = kNoQueryExpr;
+        for (std::size_t k = from; k < n; ++k) {
+            if (is_open(k)) {
+                ++pd;
+            } else if (is_close(k)) {
+                if (--pd == 0) {
+                    close = k;
+                    break;
+                }
+            }
+        }
+        if (close == kNoQueryExpr) {
+            return kNoQueryExpr;  // unbalanced
+        }
+        if (scan_query_expression(from + 1, depth + 1) != close) {
+            return kNoQueryExpr;  // content does not fill the parens as a query
+        }
+        j = close + 1;
+    } else {
+        return kNoQueryExpr;  // not a query primary (identifier, literal, operator)
+    }
+
+    // Left-associative set-operation tail: { (UNION|INTERSECT|EXCEPT) [ALL|DISTINCT]
+    // <query primary> }. Each right operand must itself be a query expression.
+    while (is_setop(j)) {
+        ++j;  // set-operation keyword
+        if (j < n && tokens[j].type == tokenizer::TokenType::Keyword &&
+            (tokens[j].keyword_id == db25::Keyword::ALL ||
+             tokens[j].keyword_id == db25::Keyword::DISTINCT)) {
+            ++j;
+        }
+        const std::size_t rhs = scan_query_expression(j, depth + 1);
+        if (rhs == kNoQueryExpr) {
+            return kNoQueryExpr;
+        }
+        j = rhs;
+    }
+    return j;
+}
+
 bool Parser::paren_group_starts_query(std::size_t from) const {
     if (tokenizer_ == nullptr) {
         return false;
     }
     const auto& tokens = tokenizer_->get_tokens();
-    std::size_t i = from;
-    // A query body may be wrapped in extra parentheses: `((SELECT 1) UNION ...)`.
-    while (i < tokens.size() &&
-           tokens[i].type == tokenizer::TokenType::Delimiter &&
-           tokens[i].value == "(") {
-        ++i;
+    // Fast path (and O(1), so deeply-nested `(SELECT * FROM (SELECT * FROM (...)))`
+    // stays linear overall rather than O(depth^2)): content that opens directly
+    // with a query keyword IS a query body - nothing can precede a SELECT / VALUES
+    // / WITH inside its parens to make it a mere operand. Only a leading '(' is
+    // ambiguous (a parenthesized subquery may be a query body OR the left operand
+    // of a scalar expression), and only that case needs the balanced scan below.
+    if (from < tokens.size() && tokens[from].type == tokenizer::TokenType::Keyword) {
+        const auto k = tokens[from].keyword_id;
+        return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
+               k == db25::Keyword::WITH;
     }
-    if (i >= tokens.size() || tokens[i].type != tokenizer::TokenType::Keyword) {
+    const std::size_t end = scan_query_expression(from, 0);
+    if (end == kNoQueryExpr) {
         return false;
     }
-    const auto k = tokens[i].keyword_id;
-    return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
-           k == db25::Keyword::WITH;
+    // The content is a query *body* only when the query expression consumes the
+    // whole group - it ends at the enclosing ')', or it runs to end-of-input (an
+    // *unclosed* query body: still route it to the subquery parser so the missing
+    // ')' is reported, matching the pre-existing lenient error path). A trailing
+    // scalar operator, as in `(SELECT 1) + 2`, leaves `end` at the operator, so
+    // the group is a grouped expression (or value list), not a subquery.
+    return end == tokens.size() ||
+           (tokens[end].type == tokenizer::TokenType::Delimiter &&
+            tokens[end].value == ")");
 }
 
 bool Parser::at_query_block_start() const {
@@ -511,9 +640,10 @@ bool Parser::at_query_block_start() const {
         return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
                k == db25::Keyword::WITH;
     }
-    // A leading '(' that (past any nested parens) begins a query is a query block
-    // too: `((SELECT 1) UNION (SELECT 2))`. parse_query_body's '(' branch then
-    // parses it via parse_parenthesized_query and folds the set-op tail.
+    // A leading '(' whose group is wholly a query expression is a query block too:
+    // `((SELECT 1) UNION (SELECT 2))`. parse_query_body's '(' branch then parses it
+    // via parse_parenthesized_query and folds the set-op tail. A group that only
+    // opens with a subquery, `((SELECT 1) + 2)`, stays a grouped expression.
     if (current_token_->type == tokenizer::TokenType::Delimiter &&
         current_token_->value == "(" && tokenizer_ != nullptr) {
         return paren_group_starts_query(tokenizer_->position());

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -711,3 +711,65 @@ TEST_F(PrecedenceRegressionTest, ParenLedQueryBodyEveryContextMatrix) {
             << "the (x) column-alias list must be retained";
     }
 }
+
+// The dual of the matrix above: a parenthesized group whose LEFT operand merely
+// happens to be a parenthesized subquery - `((SELECT 1) + 2)` - is a grouped
+// SCALAR expression, not a query body. The leading-'(' query-body recognizer must
+// not swallow the whole group as a subquery and strand the trailing operator
+// (which produced a spurious 'Unclosed parenthesis' at every gate: scalar, IN,
+// EXISTS, FROM). Each of these is legal SQL (PostgreSQL: SELECT ((SELECT 1)+2)=3).
+TEST_F(PrecedenceRegressionTest, ParenSubqueryLeftOperandStaysScalarExpr) {
+    // Binary-operator forms: the projection is a BinaryExpr with the subquery as
+    // one operand, never a bare Subquery/UnionStmt that ate the whole group.
+    const char* binary_queries[] = {
+        "SELECT ((SELECT 1) + 2) FROM z",
+        "SELECT ((SELECT max(a) FROM t) * 2) FROM z",
+        "SELECT ((SELECT 1) = 2) FROM z",
+    };
+    for (const char* sql : binary_queries) {
+        ASTNode* root = parse(sql);
+        ASSERT_NE(root, nullptr) << "rejected a legal grouped scalar expression: " << sql;
+        ASTNode* proj = first_projection(root);
+        ASSERT_NE(proj, nullptr) << sql;
+        EXPECT_EQ(proj->node_type, NodeType::BinaryExpr)
+            << sql << " -> the grouped scalar expression was mis-parsed as a query body";
+        EXPECT_NE(find(root, NodeType::Subquery), nullptr)
+            << sql << " -> the subquery operand was lost";
+    }
+    // All grouped-scalar forms (including the postfix `IS NULL`) must parse and the
+    // projection must NOT be swallowed as a query body - it is neither a bare
+    // Subquery nor a set-operation node at the projection root.
+    const char* scalar_queries[] = {
+        "SELECT ((SELECT 1) + 2) FROM z",
+        "SELECT ((SELECT 1) = 2) FROM z",
+        "SELECT ((SELECT 1) IS NULL) FROM z",
+    };
+    for (const char* sql : scalar_queries) {
+        ASTNode* root = parse(sql);
+        ASSERT_NE(root, nullptr) << "rejected a legal grouped scalar expression: " << sql;
+        ASTNode* proj = first_projection(root);
+        ASSERT_NE(proj, nullptr) << sql;
+        EXPECT_NE(proj->node_type, NodeType::Subquery)
+            << sql << " -> the group was mis-parsed as a bare subquery";
+        EXPECT_EQ(find(proj, NodeType::UnionStmt), nullptr)
+            << sql << " -> the group was mis-parsed as a set-operation query body";
+        EXPECT_NE(find(root, NodeType::Subquery), nullptr)
+            << sql << " -> the subquery operand was lost";
+    }
+    // Same misfire reached the IN and FROM/derived gates; both must accept these.
+    EXPECT_NE(parse("SELECT * FROM z WHERE x IN ((SELECT 1) + 2)"), nullptr)
+        << "IN gate rejected `IN ((SELECT 1) + 2)`";
+    EXPECT_NE(parse("SELECT * FROM z WHERE EXISTS ((SELECT 1) + 2)"), nullptr)
+        << "EXISTS gate rejected `EXISTS ((SELECT 1) + 2)`";
+    // A parenthesized FROM join group whose first ref is itself a derived table
+    // must still be a join group, not swallowed as one big derived table.
+    {
+        ASTNode* root = parse("SELECT * FROM ((SELECT 1) t1 JOIN u ON t1.a = u.a)");
+        ASSERT_NE(root, nullptr) << "((SELECT 1) t1 JOIN u ...) join group rejected";
+    }
+    // And the intended #60 query bodies must still be recognized (no over-correction).
+    EXPECT_NE(find(parse("SELECT ((SELECT 1) UNION (SELECT 2)) FROM z"), NodeType::UnionStmt), nullptr)
+        << "over-corrected: a real parenthesized set-op body is no longer a query body";
+    EXPECT_NE(find(parse("SELECT * FROM ((SELECT 1) UNION (SELECT 2)) t"), NodeType::UnionStmt), nullptr)
+        << "over-corrected: a real parenthesized set-op derived table is no longer a query body";
+}


### PR DESCRIPTION
## Summary

Seventh-pass audit finding, and a **regression from #60** (`a8a4d5c`). #60 taught the FROM / scalar / IN / EXISTS gates to recognize a leading-`(` query body so `((SELECT 1) UNION (SELECT 2))` parses as a subquery everywhere. Its helper `paren_group_starts_query` decided "query body" by **skipping all leading `(`** and checking whether the innermost token is `SELECT`/`VALUES`/`WITH`. That also matched a grouped **scalar** expression whose *left* operand merely happens to be a parenthesized subquery, so legal SQL was rejected with `'Unclosed parenthesis'`:

```sql
SELECT ((SELECT 1) + 2) FROM z              -- PostgreSQL yields 3
SELECT ((SELECT max(a) FROM t) * 2) FROM z
SELECT ((SELECT 1) IS NULL) FROM z
SELECT * FROM z WHERE x IN ((SELECT 1) + 2)
```

The group was routed to `parse_query_body`, which parsed `(SELECT 1)`, found no set-op tail to fold (`+` isn't UNION/INTERSECT/EXCEPT), and left `+ 2 )` stranded where a `)` was expected.

## Fix

`((SELECT 1))` and `((SELECT 1) + 2)` are indistinguishable from the front — both open `((SELECT` — so only a **balanced scan** of what follows the inner `)` distinguishes a query body from a scalar. `paren_group_starts_query` now uses `scan_query_expression`: a query expression is a query primary (`SELECT`/`VALUES`/`WITH`, or a parenthesized query expression that fills its parens exactly) plus an optional left-associative set-operation tail. The content is a query body only when that expression **consumes the whole group** — it ends at the enclosing `)` (or at end-of-input: an *unclosed* body is still routed to the subquery parser so the missing `)` is reported, matching the pre-existing lenient error path). A trailing scalar operator leaves the scan short of `)`, so the group is a grouped expression / value list.

## Complexity (held to the original)

- Keyword-led content (`(SELECT ...)`, including deeply nested `FROM (SELECT * FROM (...))`) short-circuits to `true` in **O(1)**.
- A leading-`(` whose innermost token isn't a query keyword (nested join group `((((t...))))`, value list) bails in **O(leading-parens)** before any balanced scan.
- Recursion is depth-capped at 256.
- `test_depth_guard`'s `DeeplyNestedFromGroupsRejected` stays **sub-second** under ASan.

## Tests

Guardrail `ParenSubqueryLeftOperandStaysScalarExpr` — the dual of #60's `ParenLedQueryBodyEveryContextMatrix`: the grouped-scalar forms parse and project a `BinaryExpr` / non-query node with the subquery nested as an operand, across the scalar / IN / EXISTS / FROM gates, while the real parenthesized set-op bodies still parse as `UnionStmt`. Also fixes the previously-failing false-positive gap in `test_edge_cases` (unclosed `FROM (SELECT * FROM users`). Full suite **37/37 green** under ASan/UBSan.
