### PR TITLE
ast: saturate ASTNode::child_count instead of wrapping at 65536 children

### DIFF
--- a/include/db25/ast/ast_node.hpp
+++ b/include/db25/ast/ast_node.hpp
@@ -22,8 +22,64 @@
 #include <vector>
 #include <expected>
 #include <utility>
+#include <type_traits>
 
 namespace db25::ast {
+
+/**
+ * A 16-bit child counter that SATURATES at 0xFFFF instead of wrapping.
+ *
+ * The AST node stores its direct-child count in 2 bytes (the packed 128-byte
+ * layout has no room to widen it). Node builders bump it with a raw `++` at
+ * ~85 sites, so on pathological, machine-generated input - a SELECT list, an
+ * IN list, or a VALUES clause with >= 65536 elements - a plain uint16_t would
+ * wrap modulo 65536. Exactly 65536 children wrap to 0, which makes
+ * get_children()'s `child_count == 0` early-out drop a fully-linked child list.
+ *
+ * Behaving like a uint16_t but capping every increment at 0xFFFF keeps the
+ * field monotonic and truthful up to 65534; 0xFFFF is a sentinel meaning
+ * ">= 65535 children - walk first_child/next_sibling for the exact count".
+ * Same size and layout as the uint16_t it replaces, so no call site changes.
+ */
+struct SaturatingChildCount {
+    static constexpr uint16_t kSaturated = 0xFFFF;
+    uint16_t value = 0;
+
+    constexpr SaturatingChildCount() noexcept = default;
+    constexpr SaturatingChildCount(uint16_t v) noexcept : value(v) {}  // NOLINT: implicit by design
+    constexpr operator uint16_t() const noexcept { return value; }
+
+    constexpr SaturatingChildCount& operator=(uint16_t v) noexcept {
+        value = v;
+        return *this;
+    }
+    constexpr SaturatingChildCount& operator++() noexcept {
+        if (value != kSaturated) {
+            ++value;
+        }
+        return *this;
+    }
+    constexpr SaturatingChildCount operator++(int) noexcept {
+        const SaturatingChildCount old = *this;
+        ++*this;
+        return old;
+    }
+    constexpr SaturatingChildCount& operator--() noexcept {
+        // Once saturated the exact count is unknown, so a decrement leaves the
+        // sentinel sticky rather than falsely claiming exactly 65534.
+        if (value != 0 && value != kSaturated) {
+            --value;
+        }
+        return *this;
+    }
+    constexpr SaturatingChildCount operator--(int) noexcept {
+        const SaturatingChildCount old = *this;
+        --*this;
+        return old;
+    }
+};
+static_assert(sizeof(SaturatingChildCount) == 2, "child count must stay 2 bytes");
+static_assert(std::is_trivially_copyable_v<SaturatingChildCount>);
 
 /**
  * 128-byte cache-aligned AST Node
@@ -42,7 +98,7 @@ struct alignas(128) ASTNode {
     // === Header (8 bytes) ===
     NodeType node_type;           // 1 byte - Node type enum
     NodeFlags flags;              // 1 byte - Boolean flags
-    uint16_t child_count;         // 2 bytes - Number of children
+    SaturatingChildCount child_count;  // 2 bytes - Number of children (saturates at 0xFFFF)
     uint32_t node_id;            // 4 bytes - Unique ID for this node
     
     // === Source Mapping (8 bytes) ===

--- a/tests/test_ast.cpp
+++ b/tests/test_ast.cpp
@@ -11,6 +11,52 @@ TEST(ASTNodeTest, SizeAndAlignment) {
     EXPECT_EQ(alignof(ASTNode), 128);
 }
 
+TEST(ASTNodeTest, ChildCountSaturatesInsteadOfWrapping) {
+    // The 2-byte child_count must saturate at 0xFFFF, never wrap. A plain uint16_t
+    // wraps modulo 65536 on a node with >= 65536 direct children (machine-generated
+    // SELECT / IN / VALUES lists); exactly 65536 wraps to 0, which would make
+    // get_children()'s `child_count == 0` early-out drop a fully-linked child list.
+    EXPECT_EQ(sizeof(SaturatingChildCount), 2u);
+
+    SaturatingChildCount c;
+    EXPECT_EQ(static_cast<uint16_t>(c), 0);
+    for (int i = 0; i < 65534; ++i) { c++; }
+    EXPECT_EQ(static_cast<uint16_t>(c), 65534);   // exact up to 65534
+    c++;
+    EXPECT_EQ(static_cast<uint16_t>(c), 65535);   // reaches the sentinel
+    c++;                                          // would wrap to 0 without saturation
+    EXPECT_EQ(static_cast<uint16_t>(c), 65535);   // stuck at 0xFFFF
+    for (int i = 0; i < 1000; ++i) { c++; }
+    EXPECT_EQ(static_cast<uint16_t>(c), 65535);   // stays saturated
+    --c;                                          // saturated count is unknown: sticky
+    EXPECT_EQ(static_cast<uint16_t>(c), 65535);
+
+    // Assignment of a small constant (the `child_count = 1/2/3` builder sites) and
+    // ordinary decrement below the sentinel behave like a plain counter.
+    c = 3;
+    EXPECT_EQ(static_cast<uint16_t>(c), 3);
+    --c;
+    EXPECT_EQ(static_cast<uint16_t>(c), 2);
+}
+
+TEST(ASTNodeTest, AddChildSaturatesAndKeepsListIntact) {
+    // add_child() bumps child_count; past the sentinel the cached count saturates
+    // but the sibling list stays fully linked, so get_children() still returns every
+    // child. This is the metadata-vs-traversal invariant the wrap would have broken.
+    ASTNode parent(NodeType::SelectList);
+    std::vector<ASTNode> kids(3);
+    for (auto& k : kids) { parent.add_child(&k); }
+    EXPECT_EQ(parent.child_count, 3);
+    EXPECT_EQ(parent.get_children().size(), 3u);
+
+    // Force the counter to the sentinel, then add one more real child.
+    parent.child_count = SaturatingChildCount::kSaturated;
+    ASTNode extra(NodeType::ColumnRef);
+    parent.add_child(&extra);
+    EXPECT_EQ(parent.child_count, SaturatingChildCount::kSaturated);  // did not wrap to 0
+    EXPECT_EQ(parent.get_children().size(), 4u);                      // list still complete
+}
+
 TEST(ASTNodeTest, DefaultConstruction) {
     const ASTNode node;
     


### PR DESCRIPTION
## Summary

Eighth-pass audit finding (minor, pathological input). `ASTNode` stores its direct-child count in a 2-byte field, bumped with a raw `++` at ~85 node-builder sites. On machine-generated input — a `SELECT` list, an `IN` list, or a `VALUES` clause with ≥ 65536 elements — a plain `uint16_t` wraps modulo 65536 (a 70000-element `IN` list reported `child_count` 4465; a 70000-column `SELECT` list 4464). The sibling list stays fully linked so traversal is correct, but the cached count that the analyzer/binder trust is wrong.

The sharp edge is **exactly 65536 children, which wrap to 0**: `get_children()` early-returns an empty vector on `child_count == 0`, dropping a fully-linked child list entirely — a correctness bug, not just bad metadata.

## Fix

The 128-byte node layout (two cache lines, `static_assert`-pinned) has no room to widen the field, and hand-saturating 85 raw `++` sites is churn-prone. Instead give the field a **type**: `SaturatingChildCount`, a `uint16_t` that caps every increment at `0xFFFF`. It converts to/from `uint16_t` and defines `++`/`--`/assignment, so all 85 call sites, the `add_child`/`remove_child` increments, and the `child_count == 0` / `reserve(child_count)` reads compile **unchanged**. Same size (`static_assert sizeof == 2`) and layout — the node stays 128 bytes.

`0xFFFF` is a documented sentinel: "≥ 65535 children — walk the sibling list for the exact count"; once saturated a decrement leaves it sticky (the exact count is no longer known).

## Tests

`test_ast`: the counter is exact through 65534, saturates at 65535, never wraps on further increments, and `add_child` past the sentinel keeps `get_children()` returning every child (the metadata-vs-traversal invariant the wrap broke). Verified end-to-end that a 65536-column `SELECT` and a 70000-element `IN` list now report `child_count == 65535` with `get_children()` returning all children. Full suite **37/37 green** under ASan/UBSan.

