### PR TITLE
parser: linear-time query-body classification (fix O(depth³) paren DoS)

### DIFF
--- a/include/db25/parser/parser.hpp
+++ b/include/db25/parser/parser.hpp
@@ -247,14 +247,6 @@ protected:
     // operand merely happens to be a parenthesized subquery, `((SELECT 1) + 2)`,
     // and from a value list / join group. Used by the FROM / scalar / IN gates.
     [[nodiscard]] bool paren_group_starts_query(std::size_t from) const;
-    // Return the token index one past a maximal query expression starting at
-    // `from`, or kNoQueryExpr if `from` does not begin one. A query expression is a
-    // query primary (SELECT / VALUES / WITH, or a parenthesized query expression
-    // that fills its parens exactly) followed by an optional left-associative
-    // set-operation tail. `depth` bounds pathological `(((...)))` nesting.
-    static constexpr std::size_t kNoQueryExpr = static_cast<std::size_t>(-1);
-    [[nodiscard]] std::size_t scan_query_expression(std::size_t from,
-                                                    std::size_t depth) const;
     // Fold a set-operation tail (UNION/INTERSECT/EXCEPT/MINUS, two precedence
     // levels, left-associative) onto an already-parsed first operand, then bind a
     // trailing ORDER BY / LIMIT to the whole result. Returns the folded node (the

--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -478,30 +478,34 @@ void Parser::attach_trailing_order_limit(ast::ASTNode* target) {
     }
 }
 
-// Parse a parenthesized query block `( <query-expression> )` and return the inner
-// query node. The inner block is a complete query (may itself be a set operation,
-// or another parenthesized block) and keeps its own ORDER BY / LIMIT. Guarded
-// against deep `((((...))))` nesting.
-std::size_t Parser::scan_query_expression(std::size_t from,
-                                          std::size_t depth) const {
-    // Guard `(((...)))` from recursing this predicate to a stack overflow; beyond
-    // any realistic nesting we conservatively report "not a query expression" and
-    // let the normal recursive-descent DepthGuard produce a graceful error.
-    constexpr std::size_t kMaxDepth = 256;
-    if (tokenizer_ == nullptr || depth > kMaxDepth) {
-        return kNoQueryExpr;
+// Does the parenthesized group whose CONTENT begins at token index `from`
+// constitute a query body - a query expression that fills the group exactly?
+//
+//   query_expr := primary ( (UNION|INTERSECT|EXCEPT) [ALL|DISTINCT] primary )*
+//   primary    := '(' query_expr ')' | (SELECT|VALUES|WITH) <body>
+//
+// This distinguishes a parenthesized query body - `(SELECT 1)`, `((SELECT 1))`,
+// `((SELECT 1) UNION (SELECT 2))` - from a grouped SCALAR expression whose left
+// operand merely opens with a subquery (`((SELECT 1) + 2)`), from an IN value
+// list (`((SELECT 1),(SELECT 2))`), and from a parenthesized join group
+// (`((SELECT 1) t JOIN u)`, `((((t...))))`). Used by the FROM / scalar / IN /
+// EXISTS gates.
+//
+// A SINGLE left-to-right linear pass, iterative (no recursion, no depth cap): a
+// deeply nested `((((SELECT 1))))` is classified in O(tokens), so the caller then
+// descends the derived-table path ONCE rather than re-running this predicate at
+// every nesting level. (The earlier recursive form re-scanned overlapping ranges
+// AND false-negatived past a 256 recursion cap, driving the FROM classifier into
+// per-level join-group recursion - an O(depth^3) parse-time DoS on legal input.)
+bool Parser::paren_group_starts_query(std::size_t from) const {
+    if (tokenizer_ == nullptr) {
+        return false;
     }
     const auto& tokens = tokenizer_->get_tokens();
     const std::size_t n = tokens.size();
     if (from >= n) {
-        return kNoQueryExpr;
+        return false;
     }
-    const auto is_setop = [&](std::size_t j) {
-        return j < n && tokens[j].type == tokenizer::TokenType::Keyword &&
-               (tokens[j].keyword_id == db25::Keyword::UNION ||
-                tokens[j].keyword_id == db25::Keyword::INTERSECT ||
-                tokens[j].keyword_id == db25::Keyword::EXCEPT);
-    };
     const auto is_open = [&](std::size_t j) {
         return tokens[j].type == tokenizer::TokenType::Delimiter &&
                tokens[j].value == "(";
@@ -510,125 +514,99 @@ std::size_t Parser::scan_query_expression(std::size_t from,
         return tokens[j].type == tokenizer::TokenType::Delimiter &&
                tokens[j].value == ")";
     };
-
-    std::size_t j;
-    const auto& head = tokens[from];
-    if (head.type == tokenizer::TokenType::Keyword &&
-        (head.keyword_id == db25::Keyword::SELECT ||
-         head.keyword_id == db25::Keyword::VALUES ||
-         head.keyword_id == db25::Keyword::WITH)) {
-        // Keyword-rooted primary: scan its body, which absorbs any operators /
-        // clauses, until - at this parenthesis level - we reach a set-operation
-        // keyword (the tail, folded below) or the enclosing ')' (or end of input).
-        int pd = 0;
-        j = from;
-        while (j < n) {
-            if (is_open(j)) {
-                ++pd;
-            } else if (is_close(j)) {
-                if (pd == 0) {
-                    break;  // the group's closing ')'
-                }
-                --pd;
-            } else if (pd == 0 && is_setop(j)) {
-                break;  // set-operation tail at this level
-            }
-            ++j;
+    const auto is_query_kw = [&](std::size_t j) {
+        if (tokens[j].type != tokenizer::TokenType::Keyword) {
+            return false;
         }
-    } else if (is_open(from)) {
-        // Parenthesized primary: it is a query primary only if its content is
-        // *itself* wholly a query expression - `(SELECT 1)`, `((SELECT 1) UNION
-        // ...)` - not a scalar expression that opens with a subquery.
-        //
-        // Cheap pre-check first: skip the run of leading '(' and require the
-        // innermost token to be a query keyword. A deeply nested join group,
-        // `((((t ...))))`, or a value list bails here in O(leading-parens) - WITHOUT
-        // the O(n) balanced scan below - so the FROM classifier stays linear per
-        // level instead of O(depth^2) over a `FROM ((((...))))` stress input.
-        std::size_t inner = from;
-        while (inner < n && is_open(inner)) {
-            ++inner;
-        }
-        if (inner >= n || tokens[inner].type != tokenizer::TokenType::Keyword) {
-            return kNoQueryExpr;
-        }
-        const auto kw = tokens[inner].keyword_id;
-        if (kw != db25::Keyword::SELECT && kw != db25::Keyword::VALUES &&
-            kw != db25::Keyword::WITH) {
-            return kNoQueryExpr;
-        }
-        // The innermost token is a query keyword: only now pay for the balanced
-        // scan that verifies the content fills the parens exactly as a query.
-        int pd = 0;
-        std::size_t close = kNoQueryExpr;
-        for (std::size_t k = from; k < n; ++k) {
-            if (is_open(k)) {
-                ++pd;
-            } else if (is_close(k)) {
-                if (--pd == 0) {
-                    close = k;
-                    break;
-                }
-            }
-        }
-        if (close == kNoQueryExpr) {
-            return kNoQueryExpr;  // unbalanced
-        }
-        if (scan_query_expression(from + 1, depth + 1) != close) {
-            return kNoQueryExpr;  // content does not fill the parens as a query
-        }
-        j = close + 1;
-    } else {
-        return kNoQueryExpr;  // not a query primary (identifier, literal, operator)
-    }
-
-    // Left-associative set-operation tail: { (UNION|INTERSECT|EXCEPT) [ALL|DISTINCT]
-    // <query primary> }. Each right operand must itself be a query expression.
-    while (is_setop(j)) {
-        ++j;  // set-operation keyword
-        if (j < n && tokens[j].type == tokenizer::TokenType::Keyword &&
-            (tokens[j].keyword_id == db25::Keyword::ALL ||
-             tokens[j].keyword_id == db25::Keyword::DISTINCT)) {
-            ++j;
-        }
-        const std::size_t rhs = scan_query_expression(j, depth + 1);
-        if (rhs == kNoQueryExpr) {
-            return kNoQueryExpr;
-        }
-        j = rhs;
-    }
-    return j;
-}
-
-bool Parser::paren_group_starts_query(std::size_t from) const {
-    if (tokenizer_ == nullptr) {
-        return false;
-    }
-    const auto& tokens = tokenizer_->get_tokens();
-    // Fast path (and O(1), so deeply-nested `(SELECT * FROM (SELECT * FROM (...)))`
-    // stays linear overall rather than O(depth^2)): content that opens directly
-    // with a query keyword IS a query body - nothing can precede a SELECT / VALUES
-    // / WITH inside its parens to make it a mere operand. Only a leading '(' is
-    // ambiguous (a parenthesized subquery may be a query body OR the left operand
-    // of a scalar expression), and only that case needs the balanced scan below.
-    if (from < tokens.size() && tokens[from].type == tokenizer::TokenType::Keyword) {
-        const auto k = tokens[from].keyword_id;
+        const auto k = tokens[j].keyword_id;
         return k == db25::Keyword::SELECT || k == db25::Keyword::VALUES ||
                k == db25::Keyword::WITH;
+    };
+    const auto is_setop = [&](std::size_t j) {
+        if (tokens[j].type != tokenizer::TokenType::Keyword) {
+            return false;
+        }
+        const auto k = tokens[j].keyword_id;
+        return k == db25::Keyword::UNION || k == db25::Keyword::INTERSECT ||
+               k == db25::Keyword::EXCEPT;
+    };
+
+    // Fast path: content opening directly with a query keyword IS a query body -
+    // nothing can precede a SELECT / VALUES / WITH inside its parens to make it a
+    // mere operand (an unclosed one is still routed to the subquery parser, which
+    // reports the missing ')').
+    if (is_query_kw(from)) {
+        return true;
     }
-    const std::size_t end = scan_query_expression(from, 0);
-    if (end == kNoQueryExpr) {
-        return false;
+
+    // `depth` counts parenthesized-primary wrappers still open. A keyword primary's
+    // OWN body parens are balanced locally (body_depth) and don't affect `depth`.
+    std::size_t i = from;
+    std::size_t depth = 0;
+    bool expect_primary = true;
+    bool saw_query = false;
+    while (i < n) {
+        if (expect_primary) {
+            if (is_open(i)) {
+                ++depth;  // open a nested parenthesized primary
+                ++i;
+                continue;
+            }
+            if (is_query_kw(i)) {
+                // Keyword-rooted primary: skip its body until, at this level, a
+                // set-op keyword or a ')' that belongs to an enclosing wrapper.
+                saw_query = true;
+                expect_primary = false;
+                ++i;
+                std::size_t body_depth = 0;
+                while (i < n) {
+                    if (is_open(i)) {
+                        ++body_depth;
+                        ++i;
+                    } else if (is_close(i)) {
+                        if (body_depth == 0) {
+                            break;  // ')' of an enclosing wrapper
+                        }
+                        --body_depth;
+                        ++i;
+                    } else if (body_depth == 0 && is_setop(i)) {
+                        break;  // set-op tail at this level
+                    } else {
+                        ++i;
+                    }
+                }
+                continue;
+            }
+            return false;  // expected a primary, got a non-query token (identifier,
+                           // literal, operator) - a join group / list / scalar expr
+        }
+        // After a primary: close wrappers, fold a set-op tail, or hit the boundary.
+        if (is_close(i)) {
+            if (depth == 0) {
+                return true;  // the enclosing group's ')': the whole content parsed
+                              // as a query expression
+            }
+            --depth;
+            ++i;
+            continue;
+        }
+        if (is_setop(i)) {
+            ++i;
+            if (i < n && tokens[i].type == tokenizer::TokenType::Keyword &&
+                (tokens[i].keyword_id == db25::Keyword::ALL ||
+                 tokens[i].keyword_id == db25::Keyword::DISTINCT)) {
+                ++i;
+            }
+            expect_primary = true;
+            continue;
+        }
+        return false;  // a trailing scalar operator (`(SELECT 1) + 2`) or a table
+                       // ref (`(SELECT 1) t JOIN ...`): not a query body
     }
-    // The content is a query *body* only when the query expression consumes the
-    // whole group - it ends at the enclosing ')', or it runs to end-of-input (an
-    // *unclosed* query body: still route it to the subquery parser so the missing
-    // ')' is reported, matching the pre-existing lenient error path). A trailing
-    // scalar operator, as in `(SELECT 1) + 2`, leaves `end` at the operator, so
-    // the group is a grouped expression (or value list), not a subquery.
-    return end == tokens.size() ||
-           (tokens[end].type == tokenizer::TokenType::Delimiter &&
-            tokens[end].value == ")");
+    // Ran to end of input with no disqualifying token: an UNCLOSED but query-shaped
+    // group. Route it to the subquery parser (which reports the missing ')'),
+    // matching the pre-existing lenient path.
+    return saw_query;
 }
 
 bool Parser::at_query_block_start() const {

--- a/tests/security/test_depth_guard.cpp
+++ b/tests/security/test_depth_guard.cpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <sstream>
+#include <chrono>
 
 #include <gtest/gtest.h>
 
@@ -239,4 +240,38 @@ TEST(DepthGuard, ParserReusableAfterDepthFailure) {
     ASSERT_TRUE(ok.has_value())
         << "Parser must be reusable after a depth failure, got: "
         << ok.error().message;
+}
+
+// A run of nested parentheses around a query body at the FROM / IN / scalar /
+// EXISTS gates must be classified and parsed in ~LINEAR time. The query-body
+// gate predicate (paren_group_starts_query) once ran a recursive balanced scan
+// re-invoked at every nesting level - an O(depth^3) parse-time DoS on inputs the
+// parser accepts (below max_depth): FROM depth 800 took ~6.5s. It is now a single
+// linear pass. A few hundred nested parens must parse in milliseconds; the very
+// generous wall-clock ceiling here (seconds) exists only to fail loudly if the
+// super-linear blowup ever returns, without being flaky under CI load.
+TEST(DepthGuard, NestedParenQueryBodyParsesInLinearTime) {
+    const auto within = [](const std::string& sql, bool expect_ok) {
+        Parser parser;
+        const auto t0 = std::chrono::steady_clock::now();
+        auto result = parser.parse(sql);
+        const double sec =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - t0).count();
+        EXPECT_EQ(result.has_value(), expect_ok) << sql.substr(0, 40);
+        // Pre-fix: ~6.5s at depth 800, ~29s at 1600. Post-fix: sub-millisecond.
+        EXPECT_LT(sec, 2.0) << "super-linear parse-time regression: " << sec << "s";
+    };
+    // depth 300 is well below max_depth (1000): these parse successfully.
+    within("SELECT * FROM " + std::string(300, '(') + "SELECT 1" + std::string(300, ')'),
+           true);
+    within("SELECT x FROM t WHERE x IN " + std::string(300, '(') + "SELECT 1" +
+               std::string(300, ')'),
+           true);
+    within("SELECT " + std::string(300, '(') + "SELECT 1" + std::string(300, ')') +
+               " FROM t",
+           true);
+    // depth 3000 exceeds max_depth: must be rejected gracefully - and, crucially,
+    // FAST (pre-fix this depth effectively hung).
+    within("SELECT * FROM " + std::string(3000, '(') + "SELECT 1" + std::string(3000, ')'),
+           false);
 }


### PR DESCRIPTION
## Summary

Tenth-pass audit finding, and a **performance regression from #60** (`a8a4d5c`). #60 routed the FROM / scalar / IN / EXISTS gates through `paren_group_starts_query()`, whose nested-`(` branch ran a **recursive** balanced scan (`scan_query_expression`): at each of up to 256 recursion levels it did an O(remaining-tokens) leading-paren skip **plus** an O(remaining-tokens) matching-`)` scan — and because the 256 cap made it **false-negative** on deeper nesting, the FROM classifier then treated the group as a join group and **recursed, re-invoking the predicate at every nesting level**.

Net **O(depth³)** parse time on inputs the parser *accepts* (below `max_depth=1000`):

```
SELECT * FROM (((…800…))) SELECT 1 …)))    -- ~6.5s   (depth 800)
                                            -- ~29s    (depth 1600)
                                            -- hangs   (depth 3200+)
```

A time / resource-exhaustion **DoS** (ASan/UBSan clean, no crash). Pre-#60 the check was an O(1) next-token peek.

## Fix

Replace the recursive predicate with a **single iterative left-to-right pass** recognizing the query-expression grammar:

```
query_expr := primary ( (UNION|INTERSECT|EXCEPT) [ALL|DISTINCT] primary )*
primary    := '(' query_expr ')' | (SELECT|VALUES|WITH) <body>
```

with an explicit wrapper-depth counter (a keyword primary's own body parens are balanced locally). **No recursion, no depth cap** — a deeply nested `((((SELECT 1))))` is classified in O(tokens), so the gate descends the derived-table path **once** instead of re-running the predicate per level. `scan_query_expression` and its `kNoQueryExpr` sentinel are removed.

**Measured:** FROM depth 800 now parses in **~0.2ms (was 6.5s)**; depth 3000 rejects gracefully in **<1ms**. IN / scalar variants likewise sub-ms.

## Correctness (all #60 / #61 guardrails still hold)

`((SELECT 1) UNION (SELECT 2))` is a query body at every gate; `((SELECT 1) + 2)` stays a grouped scalar expression; `((SELECT 1),(SELECT 2))` stays an IN value list; `((SELECT 1) t JOIN u)` stays a join group; an unclosed `(SELECT …` still routes to the subquery parser for its `)` error. New guardrail `NestedParenQueryBodyParsesInLinearTime` pins sub-2s (really sub-ms) parse time at the FROM / IN / scalar gates. Full suite **37/37 green** under ASan/UBSan.

## Tenth-pass context

One of two regressions this pass (the other, a chained USING/NATURAL mis-merge, is in the analyzer/binder cascade and will follow separately). Also outstanding: a pre-existing integer-literal-width finding and a pre-existing O(n²) flat-operator-chain perf item.

