### PR TITLE
parser: consume DISTINCT set-quantifier in set-op fold loops

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -771,10 +771,16 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
                 break;  // not INTERSECT: hand back to the union level
             }
             advance(); // consume INTERSECT
+            // Consume the optional set-quantifier. ALL keeps duplicates;
+            // DISTINCT is the default de-duplicating form and a no-op here.
+            // Both must be consumed or parse_setop_operand() sees the keyword,
+            // returns nullptr, and the RHS arm is silently dropped -- matching
+            // the ALL||DISTINCT the query-body classifier already accepts.
             bool all = false;
             if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-                (current_token_->keyword_id == db25::Keyword::ALL)) {
-                all = true;
+                (current_token_->keyword_id == db25::Keyword::ALL ||
+                 current_token_->keyword_id == db25::Keyword::DISTINCT)) {
+                all = (current_token_->keyword_id == db25::Keyword::ALL);
                 advance();
             }
             ast::ASTNode* right = parse_setop_operand();
@@ -807,10 +813,16 @@ ast::ASTNode* Parser::fold_set_operations(ast::ASTNode* first_operand) {
 
         advance(); // consume set operation keyword
 
+        // Consume the optional set-quantifier. ALL keeps duplicates; DISTINCT
+        // is the default de-duplicating form and a no-op here. Both must be
+        // consumed or parse_setop_operand() sees the keyword, returns nullptr,
+        // and the RHS arm (and every following operator) is silently dropped --
+        // matching the ALL||DISTINCT the query-body classifier already accepts.
         bool all = false;
         if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
-            (current_token_->keyword_id == db25::Keyword::ALL)) {
-            all = true;
+            (current_token_->keyword_id == db25::Keyword::ALL ||
+             current_token_->keyword_id == db25::Keyword::DISTINCT)) {
+            all = (current_token_->keyword_id == db25::Keyword::ALL);
             advance();
         }
 

--- a/tests/test_parser_fixes_phase1.cpp
+++ b/tests/test_parser_fixes_phase1.cpp
@@ -193,6 +193,47 @@ TEST_F(ParserFixesPhase1Test, UnionAllVsUnion) {
         << "UNION ALL should have ALL flag";
 }
 
+// Test 4b: explicit DISTINCT set-quantifier must not drop the RHS arm.
+// Regression: the fold loops consumed only ALL, so `UNION DISTINCT` left the
+// DISTINCT keyword in the token stream; parse_setop_operand() then failed and
+// the whole right arm (plus any following operator) was silently discarded,
+// collapsing the query to a bare SelectStmt with no diagnostic.
+TEST_F(ParserFixesPhase1Test, SetOpExplicitDistinctModifier) {
+    struct Case { const char* sql; NodeType op; };
+    const Case cases[] = {
+        {"SELECT 1 UNION DISTINCT SELECT 2",     NodeType::UnionStmt},
+        {"SELECT 1 INTERSECT DISTINCT SELECT 2", NodeType::IntersectStmt},
+        {"SELECT 1 EXCEPT DISTINCT SELECT 2",    NodeType::ExceptStmt},
+        {"(SELECT 1) UNION DISTINCT (SELECT 2)", NodeType::UnionStmt},
+    };
+    for (const auto& c : cases) {
+        parser.reset();
+        auto result = parser.parse(c.sql);
+        ASSERT_TRUE(result.has_value()) << "Failed to parse: " << c.sql;
+
+        // The set-op node must be the root: a collapse to SelectStmt is the bug.
+        auto* root = result.value();
+        ASSERT_EQ(root->node_type, c.op)
+            << "Explicit DISTINCT dropped the set operation: " << c.sql;
+
+        // Both operands must survive.
+        int operands = 0;
+        for (auto* k = root->first_child; k; k = k->next_sibling) ++operands;
+        EXPECT_EQ(operands, 2) << "RHS arm dropped for: " << c.sql;
+
+        // DISTINCT is the default de-duplicating form: no ALL flag.
+        EXPECT_FALSE(has_flag(root->flags, NodeFlags::All))
+            << "DISTINCT must not set the ALL flag: " << c.sql;
+    }
+
+    // A chained `... DISTINCT ... UNION ...` must keep every arm (left-assoc).
+    parser.reset();
+    auto chained = parser.parse("SELECT 1 UNION DISTINCT SELECT 2 UNION SELECT 3");
+    ASSERT_TRUE(chained.has_value());
+    EXPECT_EQ(chained.value()->node_type, NodeType::UnionStmt)
+        << "Chained DISTINCT set-op lost an arm";
+}
+
 // Test 5: ORDER BY DESC vs ASC
 TEST_F(ParserFixesPhase1Test, OrderByDirection) {
     std::string sql = R"(


### PR DESCRIPTION
## Problem

`SELECT 1 UNION DISTINCT SELECT 2` (and the INTERSECT/EXCEPT and parenthesized-operand forms) **silently dropped the entire right-hand arm** and every following operator, collapsing a legal query to a bare `SelectStmt(1)` with no diagnostic — a wrong-result mis-parse.

Repro (all collapse to `SelectStmt`, exit 0):
```
SELECT 1 UNION DISTINCT SELECT 2
SELECT 1 INTERSECT DISTINCT SELECT 2
SELECT 1 EXCEPT DISTINCT SELECT 2
(SELECT 1) UNION DISTINCT (SELECT 2)
SELECT 1 UNION DISTINCT SELECT 2 UNION SELECT 3
```

## Root cause

`fold_set_operations` (union level) and `fold_intersects` consumed the set-op keyword then only an optional `ALL`. On `DISTINCT` the keyword was left in the token stream; `parse_setop_operand()` saw it (not `(` / `SELECT` / `VALUES`), returned `nullptr`, and the loop broke "keeping the tree folded so far" — just the first operand.

This was internally inconsistent with the query-body classifier `paren_group_starts_query`, which already consumes an optional `ALL || DISTINCT` after a set-op keyword.

## Fix

Both fold loops now consume an optional `ALL` **or** `DISTINCT`. `DISTINCT` is the standard default de-duplicating form (`UNION [ALL|DISTINCT]`), so it is a no-op — the `All` flag stays clear. The fold path and the classifier are now consistent.

## Verification

- New regression test `SetOpExplicitDistinctModifier` (UNION/INTERSECT/EXCEPT DISTINCT, parenthesized operands, chained DISTINCT set-op).
- Full ctest suite **37/37 green under ASan + UBSan** (`-fno-sanitize-recover=all`).
- Probe matrix confirms every DISTINCT form now builds a 2-operand set-op node; `ALL`/plain forms and INTERSECT-binds-tighter precedence unchanged.

## Boundary

Pure parser-internal fix. The AST output contract (`UnionStmt`/`IntersectStmt`/`ExceptStmt` with two operands, `All` flag semantics) is unchanged — a previously-dropped arm now appears in exactly the shape downstream already expects. No downstream (analyzer/binder) contract renegotiation required.
