### PR TITLE
parser: don't require FROM for WHERE / GROUP BY / HAVING / ORDER BY

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -2735,51 +2735,16 @@ bool Parser::validate_select_stmt(ast::ASTNode* select_stmt) {
     return true;
 }
 
-bool Parser::validate_clause_dependencies(ast::ASTNode* select_stmt) {
-    bool has_from = false;
-    bool has_where = false;
-    bool has_group_by = false;
-    bool has_having = false;
-    bool has_order_by = false;
-    
-    // Scan all clauses
-    ast::ASTNode* child = select_stmt->first_child;
-    while (child) {
-        switch (child->node_type) {
-            case ast::NodeType::FromClause:
-                has_from = true;
-                break;
-            case ast::NodeType::WhereClause:
-                has_where = true;
-                break;
-            case ast::NodeType::GroupByClause:
-                has_group_by = true;
-                break;
-            case ast::NodeType::HavingClause:
-                has_having = true;
-                break;
-            case ast::NodeType::OrderByClause:
-                has_order_by = true;
-                break;
-            default:
-                break;
-        }
-        child = child->next_sibling;
-    }
-    
-    // Validate dependencies
-    // WHERE, GROUP BY, HAVING, ORDER BY all require FROM
-    if ((has_where || has_group_by || has_having || has_order_by) && !has_from) {
-        return false;  // These clauses require FROM
-    }
-    
-    // HAVING without GROUP BY is semantically questionable but syntactically valid
-    // Some databases allow it (treats whole result as one group)
-    // So we don't enforce this dependency at parse time
-    // if (has_having && !has_group_by) {
-    //     return false;
-    // }
-    
+bool Parser::validate_clause_dependencies(ast::ASTNode* /*select_stmt*/) {
+    // No clause-dependency rule is enforced at parse time. In particular a
+    // FROM-less SELECT bearing WHERE / GROUP BY / HAVING / ORDER BY is valid SQL
+    // (`SELECT 1 ORDER BY 1`, `SELECT 1 WHERE 1=1`, `SELECT 1 GROUP BY 1`,
+    // `SELECT 1 HAVING 1=1` all run in PostgreSQL / MySQL / SQLite / DuckDB), and
+    // the parser already accepts bare `SELECT 1`, `SELECT 1 LIMIT 5`, and the same
+    // FROM-less ORDER BY through the set-op path (`... UNION ... ORDER BY 1`).
+    // Requiring FROM for those clauses was both non-standard and internally
+    // inconsistent. Semantic dependencies (e.g. HAVING/ORDER BY column legality)
+    // belong to the analyzer, not the syntactic parser.
     return true;
 }
 

--- a/tests/test_edge_cases.cpp
+++ b/tests/test_edge_cases.cpp
@@ -53,8 +53,14 @@ std::vector<EdgeCase> edge_cases = {
     {"ALL/ANY operators",
      "SELECT * FROM products WHERE price > ALL (SELECT price FROM discounted)", true},
     
+    // A FROM-less SELECT bearing WHERE (or GROUP BY / HAVING / ORDER BY) is
+    // SYNTACTICALLY well-formed - the parser no longer requires FROM for those
+    // clauses (`SELECT 1 WHERE 1=1` is legal SQL). That `SELECT *` has nothing to
+    // expand and `id` resolves to no relation are SEMANTIC errors the analyzer
+    // raises, not the syntactic parser.
+    {"FROM-less WHERE parses", "SELECT * WHERE id = 1", true},
+
     // Should fail
-    {"Missing FROM", "SELECT * WHERE id = 1", false},
     {"Invalid JOIN", "SELECT * FROM t1 JOIN ON t1.id = t2.id", false},
     {"Unclosed parenthesis", "SELECT * FROM (SELECT * FROM users", false},
     {"Invalid operator", "SELECT * FROM users WHERE id === 1", false},

--- a/tests/test_parser_validation.cpp
+++ b/tests/test_parser_validation.cpp
@@ -72,7 +72,18 @@ int main() {
         
         // UNION
         {"UNION", "SELECT id FROM users UNION SELECT id FROM customers", true},
-        {"UNION ALL", "SELECT id FROM users UNION ALL SELECT id FROM customers", true}
+        {"UNION ALL", "SELECT id FROM users UNION ALL SELECT id FROM customers", true},
+
+        // FROM-less SELECT with WHERE / GROUP BY / HAVING / ORDER BY: legal SQL,
+        // must NOT be rejected (validate_clause_dependencies used to require FROM
+        // for these clauses, inconsistently with bare SELECT and the set-op path).
+        {"FROM-less ORDER BY", "SELECT 1 ORDER BY 1", true},
+        {"FROM-less ORDER BY alias", "SELECT 1+1 AS x ORDER BY x", true},
+        {"FROM-less WHERE", "SELECT 1 WHERE 1 = 1", true},
+        {"FROM-less GROUP BY", "SELECT 1 GROUP BY 1", true},
+        {"FROM-less HAVING", "SELECT 1 HAVING 1 = 1", true},
+        {"FROM-less bare SELECT", "SELECT 1", true},
+        {"FROM-less SELECT LIMIT", "SELECT 1 LIMIT 5", true}
     };
     
     Parser parser;


### PR DESCRIPTION
## Problem

`validate_clause_dependencies` rejected any FROM-less SELECT carrying `WHERE`, `GROUP BY`, `HAVING`, or `ORDER BY` — returning `Invalid SQL: validation failed` on an AST the parser had already built correctly:

```
SELECT 1 ORDER BY 1        -> rejected
SELECT 1 WHERE 1 = 1       -> rejected
SELECT 1 GROUP BY 1        -> rejected
SELECT 1 HAVING 1 = 1      -> rejected
SELECT 1+1 AS x ORDER BY x -> rejected
```

This was:
- **non-standard** — a FROM-less SELECT with those clauses is legal in PostgreSQL, MySQL, SQLite, and DuckDB (`SELECT 1 ORDER BY 1;` returns `1`); and
- **internally inconsistent** — the parser already accepts bare `SELECT 1`, `SELECT 1 LIMIT 5`, and the identical FROM-less ORDER BY via the set-op path (`SELECT 1 UNION SELECT 2 ORDER BY 1`).

## Fix

Clause-dependency legality (an `ORDER BY`/`HAVING` referencing a column, a bare `SELECT *` with no table) is a **semantic** question the analyzer answers, not a **syntactic** one. The FROM-requiring rule is removed; `validate_clause_dependencies` now enforces nothing at parse time.

## Verification

- **Downstream (the important part):** built the analyzer against this parser and ran the newly-accepted queries through `analyze()` under ASan/UBSan — the legal FROM-less forms analyze with **0 diagnostics**, and `SELECT * WHERE id = 1` is still **semantically rejected** (2 errors: `*` with no relation, unresolved `id`). No crash. Full analyzer suite **974/974** against this parser.
- New FROM-less cases in `test_parser_validation`.
- `test_edge_cases` "Missing FROM" (`SELECT * WHERE id = 1`) updated to expect a successful **parse** — the analyzer owns the semantic rejection.
- Full parser ctest **37/37** under ASan + UBSan.

## Boundary

The parser's output contract widens (it accepts more syntactically-valid ASTs). Verified the downstream consumer (analyzer) already handles the new inputs correctly — accepting the legal ones and semantically rejecting the illegal `SELECT *` case — so no analyzer/binder change is required. Semantic enforcement lands where it belongs.

