### PR TITLE
parser: accept the ALL set-quantifier in an aggregate call

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -2024,12 +2024,19 @@ ast::ASTNode* Parser::parse_function_call() {
     parenthesis_depth_++;
     advance(); // consume '('
     
-    // Check for DISTINCT keyword (for aggregate functions)
+    // Check for a leading set-quantifier (for aggregate functions). DISTINCT
+    // de-duplicates the input; ALL is its dual and the DEFAULT, so it is a no-op
+    // that must still be CONSUMED - otherwise `count(ALL x)` / `sum(ALL x)` (legal
+    // SQL) leaves ALL sitting where an argument is expected and fails to parse,
+    // while the DISTINCT sibling parses fine.
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         (current_token_->keyword_id == db25::Keyword::DISTINCT)) {
         func_call->set_flag(ast::NodeFlags::Distinct);  // Use built-in method that sets the flag properly
         func_call->semantic_flags |= static_cast<uint16_t>(ast::NodeFlags::Distinct);  // Also set semantic_flags for compatibility
         advance(); // consume DISTINCT
+    } else if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
+               (current_token_->keyword_id == db25::Keyword::ALL)) {
+        advance(); // consume ALL (the default quantifier; no flag)
     }
     
     // Parse arguments

--- a/tests/test_parser_validation.cpp
+++ b/tests/test_parser_validation.cpp
@@ -63,6 +63,10 @@ int main() {
         
         // Aggregate functions
         {"Aggregates", "SELECT COUNT(*), MAX(age), MIN(age), AVG(age), SUM(total) FROM orders", true},
+        // ALL is the default aggregate set-quantifier (the dual of DISTINCT) and
+        // must parse, not be rejected as a syntax error.
+        {"Aggregate ALL", "SELECT COUNT(ALL age), SUM(ALL total) FROM orders", true},
+        {"Aggregate DISTINCT", "SELECT COUNT(DISTINCT age) FROM orders", true},
         {"GROUP BY", "SELECT status, COUNT(*) FROM users GROUP BY status", true},
         {"HAVING", "SELECT status, COUNT(*) FROM users GROUP BY status HAVING COUNT(*) > 10", true},
         


### PR DESCRIPTION
## Problem

`parse_function_call` consumed a leading `DISTINCT` but not `ALL`, so legal aggregate calls with the `ALL` quantifier were rejected:

```
SELECT count(ALL x) FROM t   -> parse error
SELECT sum(ALL x)   FROM t   -> parse error
SELECT count(DISTINCT x) FROM t   -> OK   (the sibling parses fine)
```

`ALL` is the **default** aggregate set-quantifier — the dual of `DISTINCT` — and is legal SQL. Leaving it unconsumed left the keyword sitting where an argument was expected.

## Fix

Consume a leading `ALL` as a no-op (it's the default, so no flag is set), mirroring the existing `DISTINCT` branch. The argument is unaffected: `count(ALL x)` parses to `FunctionCall 'count'` (no `Distinct` flag) with child `ColumnRef 'x'`; `count(DISTINCT x)` still carries its flag.

## Verification

- Added `ALL`/`DISTINCT` aggregate cases to `test_parser_validation`.
- Full parser ctest **37/37** under ASan + UBSan.

## Boundary

Pure parser-internal. The AST output contract is unchanged in shape — an `ALL` call now produces the same `FunctionCall` node it always should have (identical to the unquantified form, which is correct since `ALL` is the default). No downstream change.
