### PR TITLE
parser: reject OVER &lt;named-window&gt; instead of silently mis-parsing it as an alias

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -2134,7 +2134,21 @@ ast::ASTNode* Parser::parse_function_call() {
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         (current_token_->keyword_id == db25::Keyword::OVER)) {
         advance(); // consume OVER
-        
+
+        // OVER must be followed by an inline window specification `(...)`. A
+        // named-window reference `OVER <window-name>` (resolving a WINDOW clause)
+        // is not supported - and must be REJECTED, not silently mis-parsed: with
+        // no '(' the window spec below is dropped and the leftover window name is
+        // swallowed as this function's column alias, producing an AST identical to
+        // a plain (non-windowed) call - a silent wrong result the analyzer/binder
+        // would lower to a non-windowed computation. (WINDOW-clause support is a
+        // separate feature; until then reject cleanly, as with DISTINCT ON.)
+        if (!current_token_ || current_token_->value != "(") {
+            error("window function over a named window (OVER <window-name>) is "
+                  "not supported; use an inline OVER (...) specification");
+            return nullptr;
+        }
+
         // Parse window specification
         auto* window_spec = parse_window_spec();
         if (window_spec) {

--- a/tests/test_parser_validation.cpp
+++ b/tests/test_parser_validation.cpp
@@ -66,6 +66,13 @@ int main() {
         {"GROUP BY", "SELECT status, COUNT(*) FROM users GROUP BY status", true},
         {"HAVING", "SELECT status, COUNT(*) FROM users GROUP BY status HAVING COUNT(*) > 10", true},
         
+        // Window functions: an inline OVER (...) spec parses; a named-window
+        // reference OVER <name> is unsupported and must be REJECTED, not silently
+        // mis-parsed as a column alias on the function (which drops the window).
+        {"Window inline OVER", "SELECT rank() OVER (ORDER BY age) FROM users", true},
+        {"Window empty OVER", "SELECT rank() OVER () FROM users", true},
+        {"Window named OVER rejected", "SELECT rank() OVER w FROM users", false},
+
         // ORDER BY and LIMIT
         {"ORDER BY", "SELECT * FROM users ORDER BY created_at DESC, name ASC", true},
         {"LIMIT OFFSET", "SELECT * FROM users LIMIT 10 OFFSET 20", true},


### PR DESCRIPTION
## Problem

`func() OVER <window-name>` (a named-window reference) was **silently mis-parsed**:

```
SELECT rank() OVER w FROM t WINDOW w AS (ORDER BY a)
-- parses OK, but the AST is identical to  SELECT rank() AS w FROM t
```

`parse_function_call` consumed `OVER`, `parse_window_spec()` returned `nullptr` (next token is an identifier, not `(`), nothing was attached, and the leftover window name `w` was swallowed as the function's **column alias**. The window specification vanishes — the analyzer/binder then lower it to a **non-windowed** computation. The trailing `WINDOW w AS (...)` clause is dropped as leftover tokens. A silently-wrong result on legal-looking SQL.

## Fix

Named windows / the `WINDOW` clause are a separate, unimplemented feature. Until they exist, reject `OVER` not followed by `(` **cleanly** — the same pattern the parser already uses for `DISTINCT ON is not supported` — rather than silently producing a wrong AST:

```
SELECT rank() OVER w FROM t   -> parse error: "window function over a named window
                                  (OVER <window-name>) is not supported; use an
                                  inline OVER (...) specification"
```

Inline specifications are unaffected: `OVER (...)`, `OVER ()`, `OVER (PARTITION BY .. ORDER BY ..)` all still parse.

## Verification

- Added window cases to `test_parser_validation` (inline `OVER (...)` and `OVER ()` parse; named-window `OVER w` rejected).
- Full parser ctest **37/37** under ASan + UBSan.

## Boundary

Pure parser-internal. Turns a silent wrong-AST into an honest parse error — the AST output contract is *strengthened* (a mis-shaped window-function-as-alias node is no longer emitted). No downstream change; consistent with the codebase's existing "reject unsupported feature cleanly" pattern.
