### PR TITLE
parser: reject a malformed / parenthesized UPDATE SET target instead of silently dropping clauses

### DIFF
--- a/src/parser/parser_dml.cpp
+++ b/src/parser/parser_dml.cpp
@@ -319,11 +319,20 @@ ast::ASTNode* Parser::parse_update_stmt() {
         }
         first = false;
         
-        // Parse column name
-        if (!current_token_ || 
+        // Parse column name. A SET assignment target must be a bare column name.
+        // If one is not present here a column was EXPECTED (this is either the
+        // first target after SET, or the token right after a consumed comma), so
+        // anything else is malformed - reject the statement rather than silently
+        // stopping. Silently breaking left an UpdateStmt with an empty/partial
+        // SET and every following clause (WHERE / FROM / RETURNING) discarded as
+        // leftover tokens with no diagnostic - e.g. the SQL row-assignment form
+        // `SET (a,b)=(1,2) WHERE id=1` parsed as SET-nothing and dropped the WHERE
+        // filter. The parenthesized multi-column assignment is not supported; it
+        // is rejected cleanly (like OVER <named-window> and DISTINCT ON).
+        if (!current_token_ ||
             (current_token_->type != tokenizer::TokenType::Identifier &&
              current_token_->type != tokenizer::TokenType::Keyword)) {
-            break;  // Expected column name
+            return nullptr;  // Expected a column name for the SET target
         }
         
         auto* assignment = arena_.allocate<ast::ASTNode>();
@@ -335,10 +344,11 @@ ast::ASTNode* Parser::parse_update_stmt() {
         assignment->primary_text = copy_to_arena(current_token_->value);
         advance();
         
-        // Expect = operator
+        // Expect = operator. A column name with no following `=` is malformed
+        // (`SET a b ...`); reject rather than silently dropping this and every
+        // subsequent clause.
         if (!current_token_ || current_token_->value != "=") {
-            // Arena allocated - don't delete
-            break;  // Expected =
+            return nullptr;  // Expected '=' after the SET target
         }
         advance();  // consume =
         

--- a/tests/test_parser_dml.cpp
+++ b/tests/test_parser_dml.cpp
@@ -113,6 +113,31 @@ TEST_F(DMLParseTest, DeleteWhereClause) {
     EXPECT_EQ(where->first_child->child_count, 2u);
 }
 
+// A SET assignment target must be a bare column name. The parenthesized SQL
+// row-assignment form `SET (a, b) = (1, 2)` is not supported; it must be
+// REJECTED cleanly, never silently parsed as an UpdateStmt with an empty SET and
+// every following clause (WHERE / FROM / RETURNING) dropped. Regression: the SET
+// loop broke on the leading '(' without advancing, so the WHERE filter vanished
+// with no diagnostic - an UPDATE that would touch every row.
+TEST_F(DMLParseTest, UpdateParenthesizedRowAssignmentRejected) {
+    EXPECT_EQ(parse("UPDATE t SET (a, b) = (1, 2) WHERE id = 1"), nullptr);
+    EXPECT_EQ(parse("UPDATE t SET (a, b) = (1, 2)"), nullptr);
+    // A partial parenthesized target after a valid one is rejected too (it must
+    // not silently keep only the first assignment and drop the rest + WHERE).
+    EXPECT_EQ(parse("UPDATE t SET a = 1, (b, c) = (2, 3) WHERE id = 1"), nullptr);
+    // A target with no '=' is likewise malformed, not a silent empty SET.
+    EXPECT_EQ(parse("UPDATE t SET a b WHERE id = 1"), nullptr);
+
+    // The ordinary column-assignment forms still parse, WHERE intact.
+    auto* ok = parse("UPDATE t SET a = 1, b = 2 WHERE id = 1");
+    ASSERT_NE(ok, nullptr);
+    EXPECT_EQ(ok->node_type, NodeType::UpdateStmt);
+    auto* set = find_child(ok, NodeType::SetClause);
+    ASSERT_NE(set, nullptr);
+    EXPECT_EQ(set->child_count, 2u);
+    ASSERT_NE(find_child(ok, NodeType::WhereClause), nullptr);
+}
+
 // ============================================================================
 // LIMIT negative operand
 // ============================================================================


### PR DESCRIPTION
## Summary

19th-pass F1 (parser). The `SET`-assignment loop `break`s on any token that is not a bare column name **without advancing or reporting an error**. For the SQL row-assignment form:

```sql
UPDATE t SET (a,b)=(1,2) WHERE id=1
```

the leading `(` hits that break on the first iteration, so the parser emits an `UpdateStmt` with an **empty** `SetClause` and then sees `(` where it looks for `WHERE`/`FROM`/`RETURNING` — silently discarding `(a,b)=(1,2) WHERE id=1`. `parse()` returns **success**. A binder lowering that AST gets an UPDATE with no SET targets and no row filter — one that would touch every row.

Same silent drop for `SET a=1, (b,c)=(2,3) ...` (keeps only the first assignment, drops the rest + WHERE) and `SET a b` (missing `=`).

## Fix

The parenthesized multi-column assignment is not a supported feature, so reject it cleanly — as the parser already does for `OVER <named-window>` and `DISTINCT ON`: return `nullptr` when a column name is expected but absent, and when a target is not followed by `=`. Well-formed `SET a=1, b=2 WHERE ...` is unchanged.

## Tests

`DMLParseTest.UpdateParenthesizedRowAssignmentRejected`: the parenthesized/partial/`=`-less forms are rejected; the ordinary multi-assignment form still parses with its WHERE intact. Full parser DML / negative / edge suites pass in Release and under ASan/UBSan.
