### PR TITLE
parser: reject a comma-separated GROUP BY grouping-set list instead of silently dropping items

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -389,7 +389,18 @@ ast::ASTNode* Parser::parse_select_stmt() {
             advance(); // consume BY
             
             auto* group_by = parse_group_by_clause();
-            if (group_by) {
+            if (!group_by) {
+                // parse_group_by_clause returns null in two cases. If it recorded a
+                // hard error (an unsupported comma-separated ROLLUP/CUBE/GROUPING
+                // SETS list), fail the whole parse rather than silently continue as
+                // if the GROUP BY were absent - which would drop the grouping and
+                // mis-execute the query. Otherwise the item was simply
+                // missing/empty (`... GROUP BY` with nothing after): stay lenient
+                // and continue without a grouping clause, as before.
+                if (has_error_) {
+                    return nullptr;
+                }
+            } else {
                 group_by->parent = select_node;
                 // Add to the end of child list
                 auto* last_child = select_node->first_child;
@@ -1279,7 +1290,16 @@ ast::ASTNode* Parser::parse_group_by_clause() {
                     parenthesis_depth_--;
                 }
             }
-            
+
+            // A comma here starts a comma-separated list of grouping elements
+            // (`GROUPING SETS (...), b`). The loop below is never reached from this
+            // branch, so every following item would be silently dropped. Reject
+            // the unsupported list cleanly instead of mis-grouping the query.
+            if (current_token_ && current_token_->value == ",") {
+                error("comma-separated ROLLUP/CUBE/GROUPING SETS grouping lists are not supported");
+                pop_context();
+                return nullptr;
+            }
             pop_context();
             return group_node;
         }
@@ -1329,7 +1349,15 @@ ast::ASTNode* Parser::parse_group_by_clause() {
                 parenthesis_depth_--;
             }
         }
-        
+
+        // A comma-separated list of grouping elements (`CUBE(a), ...`) is
+        // unsupported and the item loop is unreachable from here; reject cleanly
+        // rather than silently drop every following item.
+        if (current_token_ && current_token_->value == ",") {
+            error("comma-separated ROLLUP/CUBE/GROUPING SETS grouping lists are not supported");
+            pop_context();
+            return nullptr;
+        }
         pop_context();
         return group_node;
     } else if (current_token_ && (current_token_->value == "ROLLUP" || current_token_->value == "rollup")) {  // TODO: Add ROLLUP to keywords
@@ -1378,11 +1406,19 @@ ast::ASTNode* Parser::parse_group_by_clause() {
                 parenthesis_depth_--;
             }
         }
-        
+
+        // A comma-separated list of grouping elements (`ROLLUP(a), b`) is
+        // unsupported and the item loop is unreachable from here; reject cleanly
+        // rather than silently drop every following item.
+        if (current_token_ && current_token_->value == ",") {
+            error("comma-separated ROLLUP/CUBE/GROUPING SETS grouping lists are not supported");
+            pop_context();
+            return nullptr;
+        }
         pop_context();
         return group_node;
     }
-    
+
     // Regular GROUP BY items
     // Parse first GROUP BY item
     ast::ASTNode* first_item = nullptr;
@@ -1419,7 +1455,24 @@ ast::ASTNode* Parser::parse_group_by_clause() {
     while (current_token_ && current_token_->type == tokenizer::TokenType::Delimiter &&
            current_token_->value == ",") {
         advance(); // consume comma
-        
+
+        // A ROLLUP / CUBE / GROUPING SETS element is only recognized as the FIRST
+        // group-by item (handled by the branches above). Appearing later in the
+        // list it would be mis-parsed by parse_expression as an ordinary function
+        // call named ROLLUP/CUBE. A comma-separated list of grouping elements is
+        // legal SQL but unsupported here (the analyzer/binder do not model it), so
+        // reject the statement cleanly rather than mis-represent it - matching the
+        // parser's handling of other unsupported forms (OVER <named-window>,
+        // DISTINCT ON, parenthesized UPDATE SET).
+        if (current_token_ &&
+            (current_token_->value == "ROLLUP" || current_token_->value == "rollup" ||
+             current_token_->value == "CUBE" || current_token_->value == "cube" ||
+             current_token_->value == "GROUPING" || current_token_->value == "grouping")) {
+            error("comma-separated ROLLUP/CUBE/GROUPING SETS grouping lists are not supported");
+            pop_context();
+            return nullptr;
+        }
+
         ast::ASTNode* group_item = nullptr;
         
         // Could be a number (GROUP BY 1, 2), expression, or column

--- a/tests/test_group_by.cpp
+++ b/tests/test_group_by.cpp
@@ -261,3 +261,34 @@ TEST_F(GroupByTest, GroupByPosition) {
     EXPECT_EQ(pos2->node_type, NodeType::IntegerLiteral);
     EXPECT_EQ(pos2->primary_text, "2");
 }
+
+// A comma-separated LIST of grouping elements (`CUBE(a), ROLLUP(b)`), or a
+// grouping element mixed with plain items (`ROLLUP(a), b` / `a, ROLLUP(b)`), is
+// legal SQL but unsupported by this parser (the analyzer/binder do not model
+// multi-element grouping-set lists). It must be REJECTED cleanly, never silently
+// parsed as a GROUP BY over only the first element. Regression: the ROLLUP / CUBE
+// / GROUPING SETS branches returned after one element without running the
+// comma-item loop, so every following item was dropped with no diagnostic - a
+// coarser grouping that mis-executes the query.
+TEST_F(GroupByTest, GroupingSetListRejected) {
+    EXPECT_EQ(parse("SELECT a FROM t GROUP BY CUBE(a), ROLLUP(b)"), nullptr);
+    EXPECT_EQ(parse("SELECT a FROM t GROUP BY ROLLUP(a), b"), nullptr);
+    EXPECT_EQ(parse("SELECT a FROM t GROUP BY CUBE(a), b, c"), nullptr);
+    EXPECT_EQ(parse("SELECT a FROM t GROUP BY GROUPING SETS ((a)), b"), nullptr);
+    EXPECT_EQ(parse("SELECT a FROM t GROUP BY a, ROLLUP(b)"), nullptr);
+
+    // A single grouping element is still accepted (one GroupingElement child),
+    // and ordinary GROUP BY lists are unaffected.
+    auto* rollup = parse("SELECT a FROM t GROUP BY ROLLUP(a)");
+    ASSERT_NE(rollup, nullptr);
+    auto* gb1 = find_node_by_type(rollup, NodeType::GroupByClause);
+    ASSERT_NE(gb1, nullptr);
+    EXPECT_EQ(gb1->child_count, 1);
+    EXPECT_EQ(gb1->first_child->node_type, NodeType::GroupingElement);
+
+    auto* plain = parse("SELECT a, b FROM t GROUP BY a, b");
+    ASSERT_NE(plain, nullptr);
+    auto* gb2 = find_node_by_type(plain, NodeType::GroupByClause);
+    ASSERT_NE(gb2, nullptr);
+    EXPECT_EQ(gb2->child_count, 2);
+}


### PR DESCRIPTION
## Summary

20th-pass finding (the only one — analyzer, logical-plan, and contract-seam all came back clean). The `GROUPING SETS` / `CUBE` / `ROLLUP` branches of `parse_group_by_clause` each parse a **single** grouping element and `return` without running the comma-separated item loop, so a list of grouping elements silently kept only the first:

```
GROUP BY CUBE(a), ROLLUP(b)      -> GroupByClause with 1 child (ROLLUP(b) dropped)
GROUP BY ROLLUP(a), b            -> 1 child (b dropped)
GROUP BY GROUPING SETS ((a)), b  -> 1 child (b dropped)
```

`parse()` returned success with no diagnostic — a coarser grouping than written, which mis-aggregates downstream. A grouping element as a **non-first** item (`GROUP BY a, ROLLUP(b)`) was separately mis-parsed by the generic expression path as an ordinary `FunctionCall` named ROLLUP.

## Fix

A comma-separated list of grouping elements is legal SQL but unsupported here (the analyzer/binder don't model multi-element grouping-set lists), so reject it cleanly — matching the parser's handling of other unsupported forms (`OVER <named-window>`, `DISTINCT ON`, parenthesized `UPDATE SET`):

- each grouping-set branch rejects when a comma follows the element;
- the regular item loop rejects a `ROLLUP`/`CUBE`/`GROUPING SETS` keyword appearing after a comma;
- since `GROUP BY` is already consumed at the call site, a null grouping clause now **fails the whole parse** rather than being silently treated as absent (which would drop the grouping entirely).

A single grouping element (`GROUP BY ROLLUP(a)`) and ordinary comma-separated GROUP BY lists are unchanged.

## Tests

`GroupByTest.GroupingSetListRejected`. Full parser group-by / DML / negative / correctness / validation suites pass in Release and under ASan/UBSan.
