### PR TITLE
parser: only treat ROLLUP/CUBE/GROUPING as grouping constructs with the right lookahead

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -1190,8 +1190,15 @@ ast::ASTNode* Parser::parse_group_by_clause() {
     new (group_node) ast::ASTNode(ast::NodeType::GroupByClause);
     group_node->node_id = next_node_id_++;
     
-    // Check for GROUPING SETS, CUBE, or ROLLUP
-    if (current_token_ && (current_token_->value == "GROUPING" || current_token_->value == "grouping")) {  // TODO: Add GROUPING to keywords
+    // Check for GROUPING SETS, CUBE, or ROLLUP. These are NON-RESERVED keywords:
+    // each introduces a grouping construct only when ROLLUP / CUBE is immediately
+    // followed by '(' or GROUPING by SETS. Otherwise the token is a plain column
+    // identifier (`GROUP BY rollup`, `GROUP BY cube, x`), which must fall through
+    // to the ordinary item path below - dispatching on the bare keyword value
+    // hijacked such a column into an empty grouping element (or dropped the whole
+    // clause). The peek keeps this to a genuine grouping construct.
+    if (current_token_ && (current_token_->value == "GROUPING" || current_token_->value == "grouping") &&
+        peek_token_ && (peek_token_->value == "SETS" || peek_token_->value == "sets")) {  // TODO: Add GROUPING to keywords
         advance(); // consume GROUPING
         if (current_token_ && (current_token_->value == "SETS" || current_token_->value == "sets")) {  // TODO: Add SETS to keywords
             advance(); // consume SETS
@@ -1303,7 +1310,8 @@ ast::ASTNode* Parser::parse_group_by_clause() {
             pop_context();
             return group_node;
         }
-    } else if (current_token_ && (current_token_->value == "CUBE" || current_token_->value == "cube")) {  // TODO: Add CUBE to keywords
+    } else if (current_token_ && (current_token_->value == "CUBE" || current_token_->value == "cube") &&
+               peek_token_ && peek_token_->value == "(") {  // TODO: Add CUBE to keywords
         advance(); // consume CUBE
         
         // Create CUBE node
@@ -1360,7 +1368,8 @@ ast::ASTNode* Parser::parse_group_by_clause() {
         }
         pop_context();
         return group_node;
-    } else if (current_token_ && (current_token_->value == "ROLLUP" || current_token_->value == "rollup")) {  // TODO: Add ROLLUP to keywords
+    } else if (current_token_ && (current_token_->value == "ROLLUP" || current_token_->value == "rollup") &&
+               peek_token_ && peek_token_->value == "(") {  // TODO: Add ROLLUP to keywords
         advance(); // consume ROLLUP
         
         // Create ROLLUP node
@@ -1456,18 +1465,24 @@ ast::ASTNode* Parser::parse_group_by_clause() {
            current_token_->value == ",") {
         advance(); // consume comma
 
-        // A ROLLUP / CUBE / GROUPING SETS element is only recognized as the FIRST
-        // group-by item (handled by the branches above). Appearing later in the
-        // list it would be mis-parsed by parse_expression as an ordinary function
-        // call named ROLLUP/CUBE. A comma-separated list of grouping elements is
-        // legal SQL but unsupported here (the analyzer/binder do not model it), so
-        // reject the statement cleanly rather than mis-represent it - matching the
-        // parser's handling of other unsupported forms (OVER <named-window>,
-        // DISTINCT ON, parenthesized UPDATE SET).
-        if (current_token_ &&
+        // A ROLLUP(...) / CUBE(...) / GROUPING SETS(...) grouping construct as a
+        // non-first item is a comma-separated list of grouping elements: legal SQL
+        // but unsupported here (the analyzer/binder do not model it), so reject the
+        // statement cleanly rather than let parse_expression mis-represent it as an
+        // ordinary function call - matching the parser's handling of other
+        // unsupported forms (OVER <named-window>, DISTINCT ON, parenthesized UPDATE
+        // SET). This must fire ONLY for a genuine grouping construct: ROLLUP/CUBE/
+        // GROUPING are non-reserved keywords, so `GROUP BY x, rollup` where rollup
+        // is a plain column (not followed by '(' resp. SETS) is a valid two-column
+        // grouping and must parse normally.
+        const bool cur_rollup_or_cube = current_token_ &&
             (current_token_->value == "ROLLUP" || current_token_->value == "rollup" ||
-             current_token_->value == "CUBE" || current_token_->value == "cube" ||
-             current_token_->value == "GROUPING" || current_token_->value == "grouping")) {
+             current_token_->value == "CUBE" || current_token_->value == "cube");
+        const bool cur_grouping = current_token_ &&
+            (current_token_->value == "GROUPING" || current_token_->value == "grouping");
+        if ((cur_rollup_or_cube && peek_token_ && peek_token_->value == "(") ||
+            (cur_grouping && peek_token_ &&
+             (peek_token_->value == "SETS" || peek_token_->value == "sets"))) {
             error("comma-separated ROLLUP/CUBE/GROUPING SETS grouping lists are not supported");
             pop_context();
             return nullptr;

--- a/tests/test_group_by.cpp
+++ b/tests/test_group_by.cpp
@@ -292,3 +292,48 @@ TEST_F(GroupByTest, GroupingSetListRejected) {
     ASSERT_NE(gb2, nullptr);
     EXPECT_EQ(gb2->child_count, 2);
 }
+
+// ROLLUP / CUBE / GROUPING (and SETS) are NON-RESERVED keywords: they introduce a
+// grouping construct only when ROLLUP/CUBE is immediately followed by '(' or
+// GROUPING by SETS. Used as a plain column identifier they must parse as an
+// ordinary column reference. Regression: the GROUP BY branches dispatched on the
+// bare keyword value with no lookahead, so `GROUP BY rollup` produced an empty
+// ROLLUP grouping element (or dropped the whole clause), and `GROUP BY rollup, x`
+// was wrongly rejected once the grouping-set-list guard was added.
+TEST_F(GroupByTest, GroupingKeywordAsColumnName) {
+    // A single keyword-named column groups by that column.
+    for (const char* sql : {"SELECT rollup FROM t GROUP BY rollup",
+                            "SELECT cube FROM t GROUP BY cube",
+                            "SELECT g FROM t GROUP BY grouping"}) {
+        auto* ast = parse(sql);
+        ASSERT_NE(ast, nullptr) << sql;
+        auto* gb = find_node_by_type(ast, NodeType::GroupByClause);
+        ASSERT_NE(gb, nullptr) << sql;
+        EXPECT_EQ(gb->child_count, 1) << sql;
+        ASSERT_NE(gb->first_child, nullptr) << sql;
+        EXPECT_NE(gb->first_child->node_type, NodeType::GroupingElement) << sql;
+    }
+
+    // A keyword-named column mixed with others is an ordinary multi-column list,
+    // in either position.
+    auto* first = parse("SELECT rollup, x FROM t GROUP BY rollup, x");
+    ASSERT_NE(first, nullptr);
+    auto* gbf = find_node_by_type(first, NodeType::GroupByClause);
+    ASSERT_NE(gbf, nullptr);
+    EXPECT_EQ(gbf->child_count, 2);
+
+    auto* last = parse("SELECT x FROM t GROUP BY x, rollup");
+    ASSERT_NE(last, nullptr);
+    auto* gbl = find_node_by_type(last, NodeType::GroupByClause);
+    ASSERT_NE(gbl, nullptr);
+    EXPECT_EQ(gbl->child_count, 2);
+
+    // `GROUP BY rollup + 1` is an expression over the column, not a grouping set.
+    auto* expr = parse("SELECT a FROM t GROUP BY rollup + 1");
+    ASSERT_NE(expr, nullptr);
+    auto* gbe = find_node_by_type(expr, NodeType::GroupByClause);
+    ASSERT_NE(gbe, nullptr);
+    EXPECT_EQ(gbe->child_count, 1);
+    ASSERT_NE(gbe->first_child, nullptr);
+    EXPECT_NE(gbe->first_child->node_type, NodeType::GroupingElement);
+}


### PR DESCRIPTION
## Summary

21st-pass finding. `parse_group_by_clause` dispatched into the `ROLLUP` / `CUBE` / `GROUPING SETS` branches on the bare token *value*, with no lookahead. `ROLLUP`/`CUBE`/`GROUPING`/`SETS` are **non-reserved** keywords, usable as ordinary identifiers, so a column named one of them was hijacked:

```
GROUP BY rollup     -> empty GroupingElement[ROLLUP] (grand-total), not ColumnRef[rollup]
GROUP BY grouping   -> GROUPING branch consumed the token, failed the SETS check, fell through,
                       dropping the whole GROUP BY clause
GROUP BY rollup + 1 -> empty ROLLUP element, `+ 1` abandoned
GROUP BY rollup, x  -> rejected outright (a legal two-column grouping)
```

The core hijack was **pre-existing**; the grouping-set-list guard from #69 *widened* it into an outright rejection of a legal query (`GROUP BY rollup, x`).

## Fix

A grouping construct is introduced only when `ROLLUP`/`CUBE` is immediately followed by `(`, or `GROUPING` by `SETS` — otherwise the token is a plain column identifier. Gate each dispatch branch on `peek_token_` accordingly, and apply the same peek test in the comma-item grouping-set-list guard so:

- `GROUP BY rollup` / `cube` / `grouping` → ordinary column GROUP BY
- `GROUP BY rollup, x` and `GROUP BY x, rollup` → normal two-column list
- `GROUP BY ROLLUP(a)` / `CUBE(a)` / `GROUPING SETS ((a))` → grouping element (unchanged)
- `GROUP BY a, ROLLUP(b)` (a real grouping construct in a list) → still rejected (unchanged)

## Tests

`GroupByTest.GroupingKeywordAsColumnName`. Full parser ctest suite (**37/37**) passes in Release and under ASan/UBSan.
