### PR TITLE
parser: mark WITH RECURSIVE with the canonical NodeFlags::IsRecursive

### DIFF
--- a/src/parser/parser_select.cpp
+++ b/src/parser/parser_select.cpp
@@ -26,10 +26,13 @@ ast::ASTNode* Parser::parse_with_statement() {
     new (cte_clause) ast::ASTNode(ast::NodeType::CTEClause);
     cte_clause->node_id = next_node_id_++;
     
-    // Check for RECURSIVE
+    // Check for RECURSIVE. Record it as the canonical NodeFlags::IsRecursive on
+    // the WITH/CTE clause (RECURSIVE modifies the whole WITH list) so downstream
+    // stages can detect it with has_flag(NodeFlags::IsRecursive); previously it
+    // was stashed on a magic semantic_flags bit that nothing consumed.
     if (current_token_ && current_token_->type == tokenizer::TokenType::Keyword &&
         current_token_->keyword_id == db25::Keyword::RECURSIVE) {
-        cte_clause->semantic_flags |= 0x100;  // Set RECURSIVE flag (bit 8)
+        cte_clause->set_flag(ast::NodeFlags::IsRecursive);
         advance();
 #ifdef DEBUG_CTE
         if (current_token_) {

--- a/tests/test_cte.cpp
+++ b/tests/test_cte.cpp
@@ -167,17 +167,30 @@ TEST_F(CTETest, RecursiveCTE) {
     
     auto* cte_clause = find_child_by_type(ast, NodeType::CTEClause);
     ASSERT_NE(cte_clause, nullptr);
-    
-    // Should be marked as RECURSIVE
-    EXPECT_TRUE(cte_clause->semantic_flags & 0x100) << "CTE clause should have RECURSIVE flag";
-    
+
+    // Should be marked RECURSIVE via the canonical NodeFlags::IsRecursive so the
+    // analyzer/binder can detect it with has_flag (was a magic semantic_flags bit
+    // that nothing downstream consumed).
+    EXPECT_TRUE(has_flag(cte_clause->flags, NodeFlags::IsRecursive))
+        << "WITH RECURSIVE clause should carry NodeFlags::IsRecursive";
+
     auto* cte_def = find_child_by_type(cte_clause, NodeType::CTEDefinition);
     ASSERT_NE(cte_def, nullptr);
     EXPECT_EQ(cte_def->primary_text, "employee_hierarchy");
-    
+
     // Should contain a UNION statement
     auto* union_stmt = find_node_by_type(cte_def, NodeType::UnionStmt);
     ASSERT_NE(union_stmt, nullptr) << "Recursive CTE should contain UNION";
+}
+
+// A plain (non-recursive) WITH must NOT carry the recursive flag.
+TEST_F(CTETest, NonRecursiveCTEHasNoRecursiveFlag) {
+    auto* ast = parse("WITH t AS (SELECT 1 AS n) SELECT n FROM t");
+    ASSERT_NE(ast, nullptr);
+    auto* cte_clause = find_child_by_type(ast, NodeType::CTEClause);
+    ASSERT_NE(cte_clause, nullptr);
+    EXPECT_FALSE(has_flag(cte_clause->flags, NodeFlags::IsRecursive))
+        << "plain WITH must not be marked recursive";
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

First step of end-to-end **WITH RECURSIVE** support (requested feature; analyzer resolution/typing and binder lowering follow in their repos).

`parse_with_statement` recorded `RECURSIVE` on a magic `semantic_flags` bit (`|= 0x100`) that **no downstream stage consumed**, so the analyzer and binder could not tell `WITH` from `WITH RECURSIVE`. Set the canonical `NodeFlags::IsRecursive` on the `CTEClause` instead (RECURSIVE modifies the whole WITH list), so downstream can detect it with `has_flag(NodeFlags::IsRecursive)` — the same mechanism already used for `NodeFlags::All`.

The recursive body AST is already faithful: a `CTEDefinition` with an optional `ColumnList` and a `UNION [ALL]` anchor / recursive-term body.

## Tests

- `CTETest.RecursiveCTE` updated to assert the canonical flag (was asserting the old `semantic_flags & 0x100`).
- New `CTETest.NonRecursiveCTEHasNoRecursiveFlag`.

Full parser ctest suite (**37/37**) passes in Release and under ASan/UBSan.

## Follow-ups (other repos)
- **analyzer**: pre-register the recursive CTE (anchor-typed columns) before analyzing its body so the self-reference resolves; validate the recursive shape.
- **db25-logical-plan/binder**: replace the cycle-guard rejection with lowering to a recursive-union plan node over a working table.
