### PR TITLE
parser: attach CREATE TABLE ... AS SELECT body instead of dropping it

### DIFF
--- a/src/parser/parser_ddl.cpp
+++ b/src/parser/parser_ddl.cpp
@@ -978,16 +978,42 @@ ast::ASTNode* Parser::parse_create_table_impl() {
             parenthesis_depth_--;
         }
     }
-    
+
+    // CREATE TABLE ... AS <query> (CTAS): the table is defined by the result of a
+    // query. Parse the query body and attach it as a child, exactly like
+    // CREATE VIEW ... AS. Without this the table-options loop below swallowed and
+    // discarded the whole SELECT, producing a childless CreateTableStmt with a
+    // (misleading) parse success - silent loss of the query body.
+    if (current_token_ && current_token_->keyword_id == db25::Keyword::AS) {
+        advance();  // consume AS
+        // The body is any query expression (SELECT, set operation, WITH, or
+        // VALUES); dispatch through the shared query-body parser.
+        if (ast::ASTNode* body = parse_query_body()) {
+            body->parent = create_node;
+            // A column-name list may precede AS in standard CTAS; append the body
+            // after any such children rather than overwriting them.
+            if (create_node->first_child == nullptr) {
+                create_node->first_child = body;
+            } else {
+                ast::ASTNode* last = create_node->first_child;
+                while (last->next_sibling != nullptr) {
+                    last = last->next_sibling;
+                }
+                last->next_sibling = body;
+            }
+            create_node->child_count++;
+        }
+    }
+
     // Parse table options (e.g., WITHOUT ROWID, engine options, etc.)
-    while (current_token_ && 
+    while (current_token_ &&
            current_token_->type != tokenizer::TokenType::EndOfFile &&
            current_token_->value != ";") {
         // For now, just consume remaining tokens
         // TODO: Parse specific table options
         advance();
     }
-    
+
     return create_node;
 }
 

--- a/tests/test_ddl_statements.cpp
+++ b/tests/test_ddl_statements.cpp
@@ -272,6 +272,48 @@ TEST_F(DDLTest, CreateTableIfNotExists) {
     EXPECT_TRUE(ast->semantic_flags & 0x01);  // IF NOT EXISTS flag
 }
 
+// Find the first descendant (pre-order, including the root) of a node type.
+static ASTNode* find_node_type(ASTNode* n, NodeType nt) {
+    if (!n) return nullptr;
+    if (n->node_type == nt) return n;
+    for (auto* c = n->first_child; c; c = c->next_sibling) {
+        if (auto* h = find_node_type(c, nt)) return h;
+    }
+    return nullptr;
+}
+
+// CREATE TABLE ... AS SELECT (CTAS) must attach the query body as a child, not
+// silently discard it. Regression: the table-options loop swallowed the whole
+// `AS SELECT ...`, producing a childless CreateTableStmt with parse success.
+TEST_F(DDLTest, CreateTableAsSelectAttachesQueryBody) {
+    auto* ast = parse("CREATE TABLE t AS SELECT a, b FROM u WHERE x > 0");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::CreateTableStmt);
+    EXPECT_EQ(ast->primary_text, "t");
+    EXPECT_GE(ast->child_count, 1u) << "CTAS must have a query-body child";
+    auto* body = find_node_type(ast, NodeType::SelectStmt);
+    ASSERT_NE(body, nullptr) << "the AS SELECT body must be attached, not dropped";
+}
+
+// A set-operation body (CTAS over a UNION) is likewise attached.
+TEST_F(DDLTest, CreateTableAsSetOperation) {
+    auto* ast = parse("CREATE TABLE t AS SELECT 1 UNION ALL SELECT 2");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::CreateTableStmt);
+    ASSERT_NE(find_node_type(ast, NodeType::UnionStmt), nullptr)
+        << "the UNION body must be attached";
+}
+
+// A plain CREATE TABLE (no AS) is unaffected: it keeps its column-definition
+// children and has no query body.
+TEST_F(DDLTest, CreateTablePlainHasNoQueryBody) {
+    auto* ast = parse("CREATE TABLE t (id INTEGER, name TEXT)");
+    ASSERT_NE(ast, nullptr);
+    EXPECT_EQ(ast->node_type, NodeType::CreateTableStmt);
+    EXPECT_EQ(find_node_type(ast, NodeType::SelectStmt), nullptr);
+    EXPECT_GE(ast->child_count, 2u) << "two column definitions";
+}
+
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
22nd audit pass. `CREATE TABLE ... AS SELECT` (CTAS) silently discarded the entire query body.

## Root cause

`parse_create_table_impl` handled only a leading `(` column-definition list. When the next token was `AS`, it fell through to the "table options" loop, whose body just `advance()`s over every remaining token up to `;`/EOF and throws it away. So:

```sql
CREATE TABLE t AS SELECT a, b FROM u WHERE x > 0
```

parsed *"successfully"* into a **childless** `CreateTableStmt` — the whole `AS SELECT ...` subtree gone, with no error or diagnostic (silent data loss; the swallow stops at `;`, so a following statement survives, confirming it's an in-statement consume-and-discard).

## Fix

CTAS is standard SQL (SQL:2003 / Postgres), and the query-body machinery already exists — `CREATE VIEW ... AS` and `INSERT ... SELECT` both parse and attach a body. Wire it into CREATE TABLE: on `AS`, call the shared `parse_query_body()` (SELECT, set operation, WITH, or VALUES) and append the result as a child, before the options loop runs. Mirrors `parse_create_view_impl` exactly.

A plain CREATE TABLE (no `AS`) is unchanged — it keeps its column-definition children and has no query body.

## Boundary discipline

Parser-internal. Produces a faithful AST (`CreateTableStmt` → query-body child); no change to any downstream contract — downstream stages now *receive* the body they were being denied.

## Tests

Adds DDL tests: CTAS attaches a `SelectStmt` body; a `UNION` body is attached; a plain CREATE TABLE has no query child (unaffected). Full suite **37/37**.
