### PR TITLE
parser: consume array-type suffix in the ::type postfix cast

### DIFF
--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -1312,6 +1312,29 @@ ast::ASTNode* Parser::parse_cast_postfix(ast::ASTNode* operand) {
             }
         }
 
+        // Array type suffix `[]` (optionally sized / multi-dimensional, e.g.
+        // `text[]`, `int[3]`, `int[][]`). The DDL type parser handles this, but
+        // the `::type` postfix cast did not, so `x::text[]` only parsed where a
+        // later postfix pass happened to absorb the `[`; nested in parens, a
+        // function argument, or a CASE branch it was left dangling and the parse
+        // failed. Consume the suffix here so an array-type cast parses uniformly.
+        while (current_token_ && current_token_->value == "[") {
+            advance();  // consume [
+            if (current_token_ &&
+                current_token_->type == tokenizer::TokenType::Number) {
+                advance();  // optional array size, ignored (as in DDL)
+            }
+            if (current_token_ && current_token_->value == "]") {
+                advance();  // consume ]
+                type_node->flags = static_cast<ast::NodeFlags>(
+                    static_cast<uint8_t>(type_node->flags) | 0x80);  // array-type flag
+                type_node->primary_text =
+                    copy_to_arena(std::string(type_node->primary_text) + "[]");
+            } else {
+                break;  // malformed: leave it for the caller / error path
+            }
+        }
+
         operand->parent = cast_node;
         cast_node->first_child = operand;
         type_node->parent = cast_node;

--- a/tests/test_advanced_types.cpp
+++ b/tests/test_advanced_types.cpp
@@ -219,6 +219,39 @@ TEST_F(AdvancedTypesTest, ArrayOfInterval) {
     ASSERT_TRUE(result.has_value()) << "Should parse INTERVAL[] type";
 }
 
+// An array-type postfix cast (`x::text[]`) must parse in ANY expression
+// position, not only at the top level of a SELECT item / WHERE. The postfix
+// cast handler did not consume the trailing `[]`, so `x::text[]` nested in
+// parentheses, a function argument, or a CASE branch was rejected (the `[` was
+// left dangling). Regression: this is the construct in the pg_case corpus row
+// `... THEN ARRAY[...] || enum_range(...)::text[] ...`.
+TEST_F(AdvancedTypesTest, ArrayCastInNestedContexts) {
+    // Parenthesized.
+    EXPECT_TRUE(parser.parse("SELECT (x::text[])").has_value());
+    parser.reset();
+    // Function argument.
+    EXPECT_TRUE(parser.parse("SELECT f(x::text[])").has_value());
+    parser.reset();
+    // CASE branch, including the || array-concat form from the corpus.
+    EXPECT_TRUE(parser.parse(
+        "SELECT CASE WHEN true THEN ARRAY['a'] || x::text[] ELSE ARRAY['c'] END")
+                    .has_value());
+    parser.reset();
+    // The full pg_case corpus statement now parses.
+    EXPECT_TRUE(parser.parse(
+        "SELECT CASE 'foo'::text WHEN 'foo' "
+        "THEN ARRAY['a', 'b', 'c', 'd'] || enum_range(NULL::casetestenum)::text[] "
+        "ELSE ARRAY['x', 'y'] END")
+                    .has_value());
+    parser.reset();
+    // A CastExpr node is produced and marked as an array type.
+    auto result = parser.parse("SELECT CASE WHEN true THEN x::text[] END");
+    ASSERT_TRUE(result.has_value());
+    auto* cast = find_node_type(result.value(), NodeType::CastExpr);
+    ASSERT_NE(cast, nullptr);
+    EXPECT_TRUE(contains_text(cast, "[]")) << "type node records array-ness";
+}
+
 // ============================================================================
 // Summary Test
 // ============================================================================


### PR DESCRIPTION
The umbrella's new PostgreSQL differential corpus (`corpus_runner`) flagged this: `SELECT CASE 'foo'::text WHEN 'foo' THEN ARRAY[...] || enum_range(NULL::casetestenum)::text[] ELSE ARRAY[...] END` was **rejected**, though every sub-construct parses on its own.

## Root cause

`parse_cast_postfix` (the `::type` shorthand) parses the target type name and its optional `(params)` but never consumes a trailing **`[]` array-type marker**. So `x::text[]` parsed only where a later postfix pass happened to absorb the `[` — a top-level SELECT item or WHERE. Nested in parentheses, a function argument, or a CASE branch, the `[` was left dangling and the whole statement was rejected:

```sql
SELECT (x::text[])                                                     -- REJECT
SELECT f(x::text[])                                                    -- REJECT
SELECT CASE WHEN true THEN ARRAY['a'] || x::text[] ELSE ARRAY['c'] END -- REJECT
```

## Fix

Consume the `[]` suffix in `parse_cast_postfix` — optionally sized / multi-dimensional (`int[3]`, `int[][]`) — mirroring the DDL type parser (`parse_column_definition`): set the array-type flag (`0x80`) and append `[]` to the type node's text. An array-type cast now parses uniformly in every expression position, and the AST records its array-ness the same way the DDL path does.

## Boundary discipline

Parser-internal; produces the same `CastExpr` shape the DDL path already produces for array types. No downstream contract change — downstream now receives casts it was previously denied.

## Tests

`ArrayCastInNestedContexts`: array-type cast in parens, a function argument, and a CASE branch (including the `||` array-concat form); the full pg_case corpus statement; and an AST assertion that the array-ness is recorded. Full suite **37/37**.
