### PR TITLE
parser: unary +/- must bind looser than ::cast and COLLATE (F1)

### DIFF
--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -163,9 +163,21 @@ ast::ASTNode* Parser::parse_primary_expression() {
         unary_node->primary_text = copy_to_arena(op);
         
         advance(); // consume operator
-        
-        // Parse operand
+
+        // Parse operand. The `::type` postfix cast and COLLATE bind TIGHTER than
+        // unary +/- (Postgres precedence: `::`, `[]`, unary `+`/`-`, `^`, ...),
+        // so run the postfix passes on the operand right here. Otherwise the
+        // operand is a bare primary and the postfix re-binds to the WHOLE unary
+        // node up in parse_expression, mis-parsing `-a::int` as `(-a)::int`
+        // instead of `-(a::int)` (and `-'5'::int` as unary minus over a string
+        // literal - a spurious type error on a legal query).
         auto* operand = parse_primary_expression();
+        if (operand) {
+            operand = parse_collate_postfix(operand);
+        }
+        if (operand) {
+            operand = parse_cast_postfix(operand);
+        }
         if (operand) {
             operand->parent = unary_node;
             unary_node->first_child = operand;

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -773,3 +773,63 @@ TEST_F(PrecedenceRegressionTest, ParenSubqueryLeftOperandStaysScalarExpr) {
     EXPECT_NE(find(parse("SELECT * FROM ((SELECT 1) UNION (SELECT 2)) t"), NodeType::UnionStmt), nullptr)
         << "over-corrected: a real parenthesized set-op derived table is no longer a query body";
 }
+
+// -----------------------------------------------------------------------------
+// Unary +/- binds LOOSER than the `::type` postfix cast and COLLATE, so the
+// postfix must attach to the OPERAND, not re-bind to the whole unary node.
+// Postgres precedence: `::`, `[]`, unary `+`/`-`, `^`, ... Before the fix
+// `-a::int` parsed as `(-a)::int` (root CastExpr over a UnaryExpr); it must be
+// `-(a::int)` (root UnaryExpr over a CastExpr).
+TEST_F(PrecedenceRegressionTest, UnaryMinusBindsLooserThanCast) {
+    auto* root = first_projection(parse("SELECT -a::int FROM t"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);        // `-` is the root
+    EXPECT_EQ(root->primary_text, "-");
+    auto* inner = root->first_child;
+    ASSERT_NE(inner, nullptr);
+    EXPECT_EQ(inner->node_type, NodeType::CastExpr)          // cast is UNDER the minus
+        << "-a::int must parse as -(a::int), not (-a)::int";
+    // cast children are [value, Identifier(type)]; the type is `int`.
+    auto* type_node = inner->first_child ? inner->first_child->next_sibling : nullptr;
+    ASSERT_NE(type_node, nullptr);
+    EXPECT_EQ(type_node->primary_text, "int");
+}
+
+// `-'5'::int` must be `-( '5'::int )` = -5, not unary-minus over a bare string
+// literal (which the analyzer would reject as a type error on a legal query).
+TEST_F(PrecedenceRegressionTest, UnaryMinusOverCastStringLiteral) {
+    auto* root = first_projection(parse("SELECT -'5'::int"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);
+    ASSERT_NE(root->first_child, nullptr);
+    EXPECT_EQ(root->first_child->node_type, NodeType::CastExpr)
+        << "-'5'::int must parse as -('5'::int)";
+}
+
+// COLLATE is also a tighter-binding postfix: `-a COLLATE \"C\"` is
+// `-(a COLLATE \"C\")`, root UnaryExpr over a CollateClause.
+TEST_F(PrecedenceRegressionTest, UnaryMinusBindsLooserThanCollate) {
+    auto* root = first_projection(parse("SELECT -a COLLATE \"C\" FROM t"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);
+    ASSERT_NE(root->first_child, nullptr);
+    EXPECT_EQ(root->first_child->node_type, NodeType::CollateClause)
+        << "-a COLLATE \"C\" must parse as -(a COLLATE \"C\")";
+}
+
+// Guard against over-correction: a plain unary minus with no postfix is
+// unchanged, and `(-a)::int` with explicit parens still casts the negation.
+TEST_F(PrecedenceRegressionTest, UnaryMinusPlainAndParenthesizedCastUnchanged) {
+    auto* plain = first_projection(parse("SELECT -a FROM t"));
+    ASSERT_NE(plain, nullptr);
+    EXPECT_EQ(plain->node_type, NodeType::UnaryExpr);
+    ASSERT_NE(plain->first_child, nullptr);
+    EXPECT_NE(plain->first_child->node_type, NodeType::CastExpr);
+
+    auto* paren = first_projection(parse("SELECT (-a)::int FROM t"));
+    ASSERT_NE(paren, nullptr);
+    EXPECT_EQ(paren->node_type, NodeType::CastExpr)         // explicit parens: cast is root
+        << "(-a)::int must still cast the negation";
+    ASSERT_NE(paren->first_child, nullptr);
+    EXPECT_EQ(paren->first_child->node_type, NodeType::UnaryExpr);
+}


### PR DESCRIPTION
## Summary

Fixes audit finding **F1**: unary `+`/`-` bound *looser* than the `::type` postfix cast and `COLLATE`, producing a silently wrong AST for legal, fully-supported SQL.

The unary branch parsed its operand with a bare `parse_primary_expression()`, which never runs the postfix passes (`parse_collate_postfix` / `parse_cast_postfix`). Those passes are applied only to the primary up in `parse_expression`, so the postfix re-bound to the **whole unary node**:

- `-a::int` parsed as `(-a)::int` instead of Postgres's `-(a::int)`
- `-'5'::int` became unary minus over a bare string literal — a spurious type error on a legal query
- `-a COLLATE "C"` parsed as `(-a) COLLATE "C"`

`NOT` already avoids this by parsing its operand through `parse_expression(3)`.

## Fix

Run `parse_collate_postfix` + `parse_cast_postfix` on the operand right after parsing it, so `::type` and `COLLATE` attach to the inner operand first. Postgres precedence: `::`, `[]`, unary `+`/`-`, `^`, …

## Testing

`tests/test_precedence_regression.cpp`:
- `-a::int` → `-(a::int)` — `CastExpr` under the `UnaryExpr`
- `-'5'::int` → unary minus over a `CastExpr`
- `-a COLLATE "C"` → unary minus over a `CollateClause`
- guard: plain `-a` and explicit `(-a)::int` unchanged

**Falsifiable** — the three structural cases fail on the pre-fix parser (verified by reverting the source with the tests in place). Full suite **37/37**; ASan/UBSan clean.

## Scope note

General element subscripting `a[1]` (also mentioned in the finding) is not a first-class parse construct in this grammar — only array-*type* `[]` in casts, which `parse_cast_postfix` handles. This PR is scoped to the cast/COLLATE precedence that the grammar does support.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyKDAbMWGwiZq4iJx3imsg)_