### PR TITLE
parser: negative literal must bind looser than ::cast / COLLATE (audit follow-up to #77)

### DIFF
--- a/src/parser/parser_expressions.cpp
+++ b/src/parser/parser_expressions.cpp
@@ -139,21 +139,44 @@ ast::ASTNode* Parser::parse_primary_expression() {
         
         // Look ahead - if next is a number, we might combine them
         if (peek_token_ && peek_token_->type == tokenizer::TokenType::Number && op == "-") {
-            // For negative numbers, just parse as number with minus
-            advance(); // consume -
-            // Combine - with number
-            std::string combined = "-";
-            combined += std::string(current_token_->value);
+            // Negative numeric literal. The `::type` cast and COLLATE postfix
+            // bind TIGHTER than the unary minus (Postgres precedence: `::`, `[]`,
+            // unary `+`/`-`, ...), so build the UNSIGNED literal first and run the
+            // postfix passes on it. If a postfix binds, the minus applies to the
+            // whole postfixed value -> `-(5::text)`, matching the general
+            // unary-operand path (`-a::int` -> `-(a::int)`). Only when NO postfix
+            // follows do we fold the sign into the literal (the fast path for a
+            // plain `-5`). number_literal_type ignores a leading sign, so the node
+            // type is the same either way.
+            advance();  // consume '-'; current_token_ is the number
+            const std::string digits = std::string(current_token_->value);
 
             auto* num = arena_.allocate<ast::ASTNode>();
-            new (num) ast::ASTNode(internal::number_literal_type(combined));
+            new (num) ast::ASTNode(internal::number_literal_type(digits));
             num->node_id = next_node_id_++;
+            num->primary_text = copy_to_arena(digits);  // unsigned for now
+            advance();  // consume the number
 
-            num->primary_text = copy_to_arena(combined);
-            advance();
-            return num;
+            ast::ASTNode* operand = parse_collate_postfix(num);
+            if (operand) operand = parse_cast_postfix(operand);
+            if (operand == num) {
+                // No postfix bound: fold the sign into the literal (fast path).
+                num->primary_text = copy_to_arena("-" + digits);
+                return num;
+            }
+            // A postfix bound to the number; wrap the whole thing in unary minus.
+            auto* unary_node = arena_.allocate<ast::ASTNode>();
+            new (unary_node) ast::ASTNode(ast::NodeType::UnaryExpr);
+            unary_node->node_id = next_node_id_++;
+            unary_node->primary_text = copy_to_arena(op);  // "-"
+            if (operand) {
+                operand->parent = unary_node;
+                unary_node->first_child = operand;
+                unary_node->child_count = 1;
+            }
+            return unary_node;
         }
-        
+
         // Otherwise, create unary expression
         auto* unary_node = arena_.allocate<ast::ASTNode>();
         new (unary_node) ast::ASTNode(ast::NodeType::UnaryExpr);

--- a/tests/test_precedence_regression.cpp
+++ b/tests/test_precedence_regression.cpp
@@ -833,3 +833,57 @@ TEST_F(PrecedenceRegressionTest, UnaryMinusPlainAndParenthesizedCastUnchanged) {
     ASSERT_NE(paren->first_child, nullptr);
     EXPECT_EQ(paren->first_child->node_type, NodeType::UnaryExpr);
 }
+
+// A NEGATIVE NUMERIC LITERAL must obey the same postfix precedence as any other
+// unary-minus operand: `::type` and COLLATE bind tighter than the minus. The
+// negative-literal fast path used to fold `-5` into a signed literal BEFORE the
+// postfix passes, so `-5::text` mis-parsed as `(-5)::text` (root CastExpr) - a
+// legal cast of -5 - instead of Postgres's `-(5::text)` (root UnaryExpr). This
+// diverged from the sibling `-a::text` and `+5::text` paths.
+TEST_F(PrecedenceRegressionTest, NegativeLiteralCastBindsUnderMinus) {
+    auto* root = first_projection(parse("SELECT -5::text"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);       // `-` is the root
+    EXPECT_EQ(root->primary_text, "-");
+    auto* inner = root->first_child;
+    ASSERT_NE(inner, nullptr);
+    EXPECT_EQ(inner->node_type, NodeType::CastExpr)         // cast is UNDER the minus
+        << "-5::text must parse as -(5::text), not (-5)::text";
+    auto* value = inner->first_child;
+    ASSERT_NE(value, nullptr);
+    EXPECT_EQ(value->node_type, NodeType::IntegerLiteral);
+    EXPECT_EQ(value->primary_text, "5");                    // UNSIGNED under the cast
+}
+
+TEST_F(PrecedenceRegressionTest, NegativeFloatLiteralCastBindsUnderMinus) {
+    auto* root = first_projection(parse("SELECT -5.5::text"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);
+    ASSERT_NE(root->first_child, nullptr);
+    EXPECT_EQ(root->first_child->node_type, NodeType::CastExpr);
+    ASSERT_NE(root->first_child->first_child, nullptr);
+    EXPECT_EQ(root->first_child->first_child->node_type, NodeType::FloatLiteral);
+    EXPECT_EQ(root->first_child->first_child->primary_text, "5.5");
+}
+
+TEST_F(PrecedenceRegressionTest, NegativeLiteralCollateBindsUnderMinus) {
+    auto* root = first_projection(parse("SELECT -5 COLLATE \"C\""));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::UnaryExpr);
+    ASSERT_NE(root->first_child, nullptr);
+    EXPECT_EQ(root->first_child->node_type, NodeType::CollateClause)
+        << "-5 COLLATE \"C\" must parse as -(5 COLLATE \"C\")";
+}
+
+// Guard: a plain negative literal with NO postfix still folds into one signed
+// numeric literal (the fast path is preserved, not regressed into a UnaryExpr).
+TEST_F(PrecedenceRegressionTest, PlainNegativeLiteralStillFolds) {
+    auto* root = first_projection(parse("SELECT -5"));
+    ASSERT_NE(root, nullptr);
+    EXPECT_EQ(root->node_type, NodeType::IntegerLiteral);
+    EXPECT_EQ(root->primary_text, "-5");
+    auto* f = first_projection(parse("SELECT -5.5"));
+    ASSERT_NE(f, nullptr);
+    EXPECT_EQ(f->node_type, NodeType::FloatLiteral);
+    EXPECT_EQ(f->primary_text, "-5.5");
+}


### PR DESCRIPTION
## Summary

Fixes audit finding: a **negative numeric literal** bound *looser* than the `::type` cast and `COLLATE` postfix, contradicting the precedence rule established in #77 (9d32b4b) and PostgreSQL. `-5::text` parsed as `(-5)::text` (a legal cast of `-5`) instead of `-(5::text)`.

This is the incomplete-fix tail of #77: that change routed the **general** unary-operand path through the postfix passes (`-a::int → -(a::int)`), but the negative-**numeric-literal** fast path folded `-5` into a signed literal *before* the postfix ran — so `-5::text` and `-5 COLLATE "C"` stayed wrong and inconsistent with the sibling `-a::text` / `+5::text` paths.

## Fix

Build the **unsigned** literal first and run `parse_collate_postfix` / `parse_cast_postfix` on it; if a postfix binds, wrap the result in a unary minus (`-(N::type)`); only when no postfix follows, fold the sign into the literal (the plain-`-5` fast path, preserved). `number_literal_type` ignores a leading sign, so the node type is unchanged either way.

## Testing

`tests/test_precedence_regression.cpp`:
- `-5::text`, `-5.5::text` → `UnaryExpr` over `CastExpr` with the **unsigned** literal beneath;
- `-5 COLLATE "C"` → `UnaryExpr` over `CollateClause`;
- guard: plain `-5` / `-5.5` still fold to one signed literal.

**Falsifiable** — the three postfix cases fail on the pre-fix parser (verified by revert). Full suite **37/37**; ASan/UBSan clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyKDAbMWGwiZq4iJx3imsg)_